### PR TITLE
Fix redirect methods used when setting StatusSeeOther response status

### DIFF
--- a/http.go
+++ b/http.go
@@ -70,7 +70,7 @@ func setHTMLResponse(w http.ResponseWriter) {
 }
 
 func isSeeOtherRedirectMethod(method string) bool {
-	return method == http.MethodPost || method == http.MethodPatch || method == http.MethodPut
+	return method == http.MethodPut || method == http.MethodPatch || method == http.MethodDelete
 }
 
 func refererFromRequest(r *http.Request) string {

--- a/middleware.go
+++ b/middleware.go
@@ -59,7 +59,7 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 			i.Back(w2, r)
 		}
 
-		// The POST, PUT and PATCH requests cannot have the 302 code status.
+		// The PUT, PATCH and DELETE requests cannot have the 302 code status.
 		// Let's set the status code to the 303 instead.
 		//
 		// https://inertiajs.com/redirects#303-response-code


### PR DESCRIPTION
Fix redirect methods used when setting StatusSeeOther response status to include DELETE and remove POST (as per https://inertiajs.com/redirects#303-response-code and Laravel implementation https://github.com/inertiajs/inertia-laravel/blob/1.x/src/Middleware.php#L101).