### PR TITLE
Fix client-side location not visiting (hard reloading) when returning 409 StatusConflict upon Inertia asset version change.

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -25,6 +25,15 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Determines what to do when the Inertia asset version has changed.
+		// By default, we'll initiate a client-side location visit to force an update.
+		//
+		// https://inertiajs.com/asset-versioning
+		if r.Method == http.MethodGet && inertiaVersionFromRequest(r) != i.version {
+			i.Location(w, r, r.URL.RequestURI())
+			return
+		}
+
 		// Now we know that this request was made by Inertia.
 		//
 		// But there is one problem:
@@ -38,25 +47,11 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 		// Now put our response writer wrapper to other handlers.
 		next.ServeHTTP(w2, r)
 
-		// Our response writer wrapper does have all needle data! Yuppy!
-		//
-		// Don't forget to copy all data to the original
-		// response writer before end!
-		defer i.copyWrapperResponse(w, w2)
-
-		// Determines what to do when the Inertia asset version has changed.
-		// By default, we'll initiate a client-side location visit to force an update.
-		//
-		// https://inertiajs.com/asset-versioning
-		if r.Method == http.MethodGet && inertiaVersionFromRequest(r) != i.version {
-			i.Location(w2, r, r.URL.RequestURI())
-			return
-		}
-
 		// Determines what to do when an Inertia action returned empty response.
 		// By default, we will redirect the user back to where he came from.
 		if w2.StatusCode() == http.StatusOK && w2.IsEmpty() {
-			i.Back(w2, r)
+			i.Back(w, r)
+			return
 		}
 
 		// The PUT, PATCH and DELETE requests cannot have the 302 code status.
@@ -66,6 +61,12 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 		if w2.StatusCode() == http.StatusFound && isSeeOtherRedirectMethod(r.Method) {
 			setResponseStatus(w2, http.StatusSeeOther)
 		}
+
+		// Our response writer wrapper does have all needle data! Yuppy!
+		//
+		// Don't forget to copy all data to the original
+		// response writer before end!
+		i.copyWrapperResponse(w, w2)
 	})
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -25,15 +25,6 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Determines what to do when the Inertia asset version has changed.
-		// By default, we'll initiate a client-side location visit to force an update.
-		//
-		// https://inertiajs.com/asset-versioning
-		if r.Method == http.MethodGet && inertiaVersionFromRequest(r) != i.version {
-			i.Location(w, r, r.URL.RequestURI())
-			return
-		}
-
 		// Now we know that this request was made by Inertia.
 		//
 		// But there is one problem:
@@ -46,6 +37,15 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 
 		// Now put our response writer wrapper to other handlers.
 		next.ServeHTTP(w2, r)
+
+		// Determines what to do when the Inertia asset version has changed.
+		// By default, we'll initiate a client-side location visit to force an update.
+		//
+		// https://inertiajs.com/asset-versioning
+		if r.Method == http.MethodGet && inertiaVersionFromRequest(r) != i.version {
+			i.Location(w, r, r.URL.RequestURI())
+			return
+		}
 
 		// Determines what to do when an Inertia action returned empty response.
 		// By default, we will redirect the user back to where he came from.


### PR DESCRIPTION
A small refactor to fix client-side not reloading when Inertia has a new asset version. Client side gets a 409 response and does nothing with it - doesn't make a full visit to X-Inertia-Location.
I think a culprit might be that either a response body is not empty or that Content-Type is set to application/json or both of those things.

Now when returning only 2 headers: Vary: X-Inertia and X-Inertia-Location: ... with no other headers and an empty body, it works well and makes a full visit.

Also, I made an early return for this part:
```go
if w2.StatusCode() == http.StatusOK && w2.IsEmpty() {
    i.Back(w, r)
    return
}
```