### PR TITLE
Fix empty response redirect issue introduced by https://github.com/romsar/gonertia/pull/14

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -47,11 +47,16 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Our response writer wrapper does have all needle data! Yuppy!
+		//
+		// Don't forget to copy all data to the original
+		// response writer before end!
+		defer i.copyWrapperResponse(w, w2)
+
 		// Determines what to do when an Inertia action returned empty response.
 		// By default, we will redirect the user back to where he came from.
 		if w2.StatusCode() == http.StatusOK && w2.IsEmpty() {
-			i.Back(w, r)
-			return
+			i.Back(w2, r)
 		}
 
 		// The PUT, PATCH and DELETE requests cannot have the 302 code status.
@@ -61,12 +66,6 @@ func (i *Inertia) Middleware(next http.Handler) http.Handler {
 		if w2.StatusCode() == http.StatusFound && isSeeOtherRedirectMethod(r.Method) {
 			setResponseStatus(w2, http.StatusSeeOther)
 		}
-
-		// Our response writer wrapper does have all needle data! Yuppy!
-		//
-		// Don't forget to copy all data to the original
-		// response writer before end!
-		i.copyWrapperResponse(w, w2)
 	})
 }
 


### PR DESCRIPTION
Move `defer i.copyWrapperResponse(w, w2)` before empty response check and remove an early return after i.Back, so that PUT, PATCH or DELETE requests with empty **200** response will get a correct http.StatusSeeOther response status redirect instead of a default http.StatusFound.