### PR TITLE
Add New `NewFromTemplate` Constructor for Parsed Templates

### DIFF
--- a/inertia.go
+++ b/inertia.go
@@ -84,6 +84,31 @@ func NewFromBytes(rootTemplateBs []byte, opts ...Option) (*Inertia, error) {
 	return New(string(rootTemplateBs), opts...)
 }
 
+// NewFromTemplate receives a *template.Template and then initializes Inertia.
+func NewFromTemplate(rootTemplate *template.Template, opts ...Option) (*Inertia, error) {
+	if rootTemplate == nil {
+		return nil, fmt.Errorf("nil root template")
+	}
+
+	i := &Inertia{
+		rootTemplate:        rootTemplate,
+		jsonMarshaller:      jsonDefaultMarshaller{},
+		containerID:         "app",
+		logger:              log.New(io.Discard, "", 0),
+		sharedProps:         make(Props),
+		sharedTemplateData:  make(TemplateData),
+		sharedTemplateFuncs: make(TemplateFuncs),
+	}
+
+	for _, opt := range opts {
+		if err := opt(i); err != nil {
+			return nil, fmt.Errorf("initialize inertia: %w", err)
+		}
+	}
+
+	return i, nil
+}
+
 // Logger defines an interface for debug messages.
 type Logger interface {
 	Printf(format string, v ...any)

--- a/inertia.go
+++ b/inertia.go
@@ -91,13 +91,12 @@ func NewFromTemplate(rootTemplate *template.Template, opts ...Option) (*Inertia,
 	}
 
 	i := &Inertia{
-		rootTemplate:        rootTemplate,
-		jsonMarshaller:      jsonDefaultMarshaller{},
-		containerID:         "app",
-		logger:              log.New(io.Discard, "", 0),
-		sharedProps:         make(Props),
-		sharedTemplateData:  make(TemplateData),
-		sharedTemplateFuncs: make(TemplateFuncs),
+		rootTemplate:       rootTemplate,
+		jsonMarshaller:     jsonDefaultMarshaller{},
+		containerID:        "app",
+		logger:             log.New(io.Discard, "", 0),
+		sharedProps:        make(Props),
+		sharedTemplateData: make(TemplateData),
 	}
 
 	for _, opt := range opts {

--- a/inertia.go
+++ b/inertia.go
@@ -12,12 +12,12 @@ import (
 
 // Inertia is a main Gonertia structure, which contains all the logic for being an Inertia adapter.
 type Inertia struct {
-	rootTemplate *template.Template
-	// rootTemplateHTML string
+	rootTemplate     *template.Template
+	rootTemplateHTML string
 
-	sharedProps        Props
-	sharedTemplateData TemplateData
-	// sharedTemplateFuncs TemplateFuncs
+	sharedProps         Props
+	sharedTemplateData  TemplateData
+	sharedTemplateFuncs TemplateFuncs
 
 	flash FlashProvider
 
@@ -37,16 +37,20 @@ func New(rootTemplateHTML string, opts ...Option) (*Inertia, error) {
 		return nil, fmt.Errorf("blank root template")
 	}
 
-	tmpl, err := template.New("root").
-		Funcs(template.FuncMap(make(TemplateFuncs))).
-		Parse(rootTemplateHTML)
-	if err != nil {
-		return nil, fmt.Errorf("build root template: %w", err)
+	i := &Inertia{
+		rootTemplateHTML:    rootTemplateHTML,
+		jsonMarshaller:      jsonDefaultMarshaller{},
+		containerID:         "app",
+		logger:              log.New(io.Discard, "", 0),
+		sharedProps:         make(Props),
+		sharedTemplateData:  make(TemplateData),
+		sharedTemplateFuncs: make(TemplateFuncs),
 	}
 
-	i, err := NewFromTemplate(tmpl, opts...)
-	if err != nil {
-		return nil, err
+	for _, opt := range opts {
+		if err := opt(i); err != nil {
+			return nil, fmt.Errorf("initialize inertia: %w", err)
+		}
 	}
 
 	return i, nil
@@ -87,13 +91,13 @@ func NewFromTemplate(rootTemplate *template.Template, opts ...Option) (*Inertia,
 	}
 
 	i := &Inertia{
-		rootTemplate:       rootTemplate,
-		jsonMarshaller:     jsonDefaultMarshaller{},
-		containerID:        "app",
-		logger:             log.New(io.Discard, "", 0),
-		sharedProps:        make(Props),
-		sharedTemplateData: make(TemplateData),
-		// sharedTemplateFuncs: make(TemplateFuncs),
+		rootTemplate:        rootTemplate,
+		jsonMarshaller:      jsonDefaultMarshaller{},
+		containerID:         "app",
+		logger:              log.New(io.Discard, "", 0),
+		sharedProps:         make(Props),
+		sharedTemplateData:  make(TemplateData),
+		sharedTemplateFuncs: make(TemplateFuncs),
 	}
 
 	for _, opt := range opts {
@@ -140,19 +144,13 @@ func (i *Inertia) ShareTemplateData(key string, val any) {
 	i.sharedTemplateData[key] = val
 }
 
-// // ShareTemplateFunc adds passed value to the shared template func map.
-// func (i *Inertia) ShareTemplateFunc(key string, val any) error {
-// 	i.sharedTemplateFuncs[key] = val
-//
-// 	if i.rootTemplateHTML == "" {
-// 		return fmt.Errorf("no root template string defined")
-// 	}
-//
-// 	t, err := buildRootTemplate(i.rootTemplateHTML, i.sharedTemplateFuncs)
-// 	if err != nil {
-// 		return fmt.Errorf("rebuild root template: %w", err)
-// 	}
-//
-// 	i.rootTemplate = t
-// 	return nil
-// }
+// ShareTemplateFunc adds the passed value to the shared template func map. If
+// no root template HTML string has been defined, it returns an error.
+func (i *Inertia) ShareTemplateFunc(key string, val any) error {
+	if i.rootTemplateHTML == "" {
+		return fmt.Errorf("undefined root template html string")
+	}
+
+	i.sharedTemplateFuncs[key] = val
+	return nil
+}

--- a/inertia_test.go
+++ b/inertia_test.go
@@ -1,6 +1,7 @@
 package gonertia
 
 import (
+	"html/template"
 	"reflect"
 	"strings"
 	"testing"
@@ -76,6 +77,33 @@ func TestNewFromBytes(t *testing.T) {
 	if i.rootTemplateHTML != rootTemplate {
 		t.Fatalf("root template html=%s, want=%s", i.rootTemplateHTML, rootTemplate)
 	}
+}
+
+func TestNewFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		tmpl := template.Must(template.New("foo").Parse(`<div id="app"></div>`))
+		i, err := NewFromTemplate(tmpl)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if i.rootTemplate == nil {
+			t.Fatalf("missing root template")
+		}
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		i, err := NewFromTemplate(nil)
+		if err == nil {
+			t.Fatalf("expected error for passing a nil template")
+		}
+		if i != nil {
+			t.Fatalf("expected Inertia instance to be nil, but got %v", i)
+		}
+	})
 }
 
 func TestInertia_ShareProp(t *testing.T) {

--- a/inertia_test.go
+++ b/inertia_test.go
@@ -23,9 +23,7 @@ func TestNew(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 
-		if i.rootTemplateHTML != rootTemplate {
-			t.Fatalf("root template html=%s, want=%s", i.rootTemplateHTML, rootTemplate)
-		}
+		assertRootTemplate(t, i.rootTemplate)
 	})
 
 	t.Run("blank", func(t *testing.T) {
@@ -48,9 +46,7 @@ func TestNewFromFile(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if i.rootTemplateHTML != rootTemplate {
-		t.Fatalf("root template html=%s, want=%s", i.rootTemplateHTML, rootTemplate)
-	}
+	assertRootTemplate(t, i.rootTemplate)
 }
 
 func TestNewFromReader(t *testing.T) {
@@ -61,9 +57,7 @@ func TestNewFromReader(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if i.rootTemplateHTML != rootTemplate {
-		t.Fatalf("root template html=%s, want=%s", i.rootTemplateHTML, rootTemplate)
-	}
+	assertRootTemplate(t, i.rootTemplate)
 }
 
 func TestNewFromBytes(t *testing.T) {
@@ -74,9 +68,7 @@ func TestNewFromBytes(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if i.rootTemplateHTML != rootTemplate {
-		t.Fatalf("root template html=%s, want=%s", i.rootTemplateHTML, rootTemplate)
-	}
+	assertRootTemplate(t, i.rootTemplate)
 }
 
 func TestNewFromTemplate(t *testing.T) {
@@ -300,52 +292,67 @@ func TestInertia_ShareTemplateData(t *testing.T) {
 	}
 }
 
-func TestInertia_ShareTemplateFunc(t *testing.T) {
-	t.Parallel()
+// func TestInertia_ShareTemplateFunc(t *testing.T) {
+// 	t.Parallel()
+//
+// 	type args struct {
+// 		key string
+// 		val any
+// 	}
+// 	tests := []struct {
+// 		name          string
+// 		templateFuncs TemplateFuncs
+// 		args          args
+// 		want          TemplateFuncs
+// 	}{
+// 		{
+// 			"add",
+// 			TemplateFuncs{},
+// 			args{
+// 				key: "foo",
+// 				val: "bar",
+// 			},
+// 			TemplateFuncs{"foo": "bar"},
+// 		},
+// 		{
+// 			"replace",
+// 			TemplateFuncs{"foo": "zoo"},
+// 			args{
+// 				key: "foo",
+// 				val: "bar",
+// 			},
+// 			TemplateFuncs{"foo": "bar"},
+// 		},
+// 	}
+//
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			t.Parallel()
+//
+// 			i := I(func(i *Inertia) {
+// 				i.sharedTemplateFuncs = tt.templateFuncs
+// 			})
+//
+// 			 i.ShareTemplateFunc(tt.args.key, tt.args.val)
+//
+// 			if !reflect.DeepEqual(i.sharedTemplateFuncs, tt.want) {
+// 				t.Fatalf("sharedTemplateFuncs=%#v, want=%#v", i.sharedTemplateFuncs, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-	type args struct {
-		key string
-		val any
+func assertRootTemplate(t *testing.T, root *template.Template) {
+	t.Helper()
+
+	control, err := template.New("root").
+		Funcs(template.FuncMap(make(TemplateFuncs))).
+		Parse(rootTemplate)
+	if err != nil {
+		t.Fatalf("parse root template: %v", err)
 	}
-	tests := []struct {
-		name          string
-		templateFuncs TemplateFuncs
-		args          args
-		want          TemplateFuncs
-	}{
-		{
-			"add",
-			TemplateFuncs{},
-			args{
-				key: "foo",
-				val: "bar",
-			},
-			TemplateFuncs{"foo": "bar"},
-		},
-		{
-			"replace",
-			TemplateFuncs{"foo": "zoo"},
-			args{
-				key: "foo",
-				val: "bar",
-			},
-			TemplateFuncs{"foo": "bar"},
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			i := I(func(i *Inertia) {
-				i.sharedTemplateFuncs = tt.templateFuncs
-			})
-
-			i.ShareTemplateFunc(tt.args.key, tt.args.val)
-
-			if !reflect.DeepEqual(i.sharedTemplateFuncs, tt.want) {
-				t.Fatalf("sharedTemplateFuncs=%#v, want=%#v", i.sharedTemplateFuncs, tt.want)
-			}
-		})
+	if strings.TrimSpace(root.Tree.Root.String()) != strings.TrimSpace(control.Tree.Root.String()) {
+		t.Fatalf("rootTemplate=%#v, want=%#v", root, control)
 	}
 }

--- a/response.go
+++ b/response.go
@@ -445,6 +445,14 @@ func (i *Inertia) doInertiaResponse(w http.ResponseWriter, page *page) error {
 }
 
 func (i *Inertia) doHTMLResponse(w http.ResponseWriter, r *http.Request, page *page) (err error) {
+	// If root template is already created - we'll use it to save some time.
+	if i.rootTemplate == nil {
+		i.rootTemplate, err = i.buildRootTemplate()
+		if err != nil {
+			return fmt.Errorf("build root template: %w", err)
+		}
+	}
+
 	templateData, err := i.buildTemplateData(r, page)
 	if err != nil {
 		return fmt.Errorf("build template data: %w", err)
@@ -457,6 +465,11 @@ func (i *Inertia) doHTMLResponse(w http.ResponseWriter, r *http.Request, page *p
 	}
 
 	return nil
+}
+
+func (i *Inertia) buildRootTemplate() (*template.Template, error) {
+	tmpl := template.New("").Funcs(template.FuncMap(i.sharedTemplateFuncs))
+	return tmpl.Parse(i.rootTemplateHTML)
 }
 
 func (i *Inertia) buildTemplateData(r *http.Request, page *page) (TemplateData, error) {

--- a/response.go
+++ b/response.go
@@ -445,14 +445,6 @@ func (i *Inertia) doInertiaResponse(w http.ResponseWriter, page *page) error {
 }
 
 func (i *Inertia) doHTMLResponse(w http.ResponseWriter, r *http.Request, page *page) (err error) {
-	// If root template is already created - we'll use it to save some time.
-	if i.rootTemplate == nil {
-		i.rootTemplate, err = i.buildRootTemplate()
-		if err != nil {
-			return fmt.Errorf("build root template: %w", err)
-		}
-	}
-
 	templateData, err := i.buildTemplateData(r, page)
 	if err != nil {
 		return fmt.Errorf("build template data: %w", err)
@@ -465,11 +457,6 @@ func (i *Inertia) doHTMLResponse(w http.ResponseWriter, r *http.Request, page *p
 	}
 
 	return nil
-}
-
-func (i *Inertia) buildRootTemplate() (*template.Template, error) {
-	tmpl := template.New("").Funcs(template.FuncMap(i.sharedTemplateFuncs))
-	return tmpl.Parse(i.rootTemplateHTML)
 }
 
 func (i *Inertia) buildTemplateData(r *http.Request, page *page) (TemplateData, error) {

--- a/response_test.go
+++ b/response_test.go
@@ -21,18 +21,18 @@ func TestInertia_Render(t *testing.T) {
 	t.Run("plain request", func(t *testing.T) {
 		t.Parallel()
 
-		// t.Run("success", func(t *testing.T) {
-		// 	t.Parallel()
-		//
-		// 	i := I(func(i *Inertia) {
-		// 		i.rootTemplateHTML = rootTemplate
-		// 		i.version = "f8v01xv4h4"
-		// 	})
-		//
-		// 	assertRootTemplateSuccess(t, i)
-		// })
-
 		t.Run("success", func(t *testing.T) {
+			t.Parallel()
+
+			i := I(func(i *Inertia) {
+				i.rootTemplateHTML = rootTemplate
+				i.version = "f8v01xv4h4"
+			})
+
+			assertRootTemplateSuccess(t, i)
+		})
+
+		t.Run("success with pre-parsed template", func(t *testing.T) {
 			t.Parallel()
 
 			tmpl, err := template.New("root").
@@ -136,24 +136,24 @@ func TestInertia_Render(t *testing.T) {
 				assertable.AssertURL("/home")
 			}
 
-			// t.Run("success", func(t *testing.T) {
-			// 	t.Parallel()
-			//
-			// 	ts := newTestServerSSR(t)
-			//
-			// 	defer ts.Close()
-			//
-			// 	i := I(func(i *Inertia) {
-			// 		i.rootTemplateHTML = rootTemplate
-			// 		i.version = "f8v01xv4h4"
-			// 		i.ssrURL = ts.URL
-			// 		i.ssrHTTPClient = ts.Client()
-			// 	})
-			//
-			// 	successRunner(t, i)
-			// })
-
 			t.Run("success", func(t *testing.T) {
+				t.Parallel()
+
+				ts := newTestServerSSR(t)
+
+				defer ts.Close()
+
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = rootTemplate
+					i.version = "f8v01xv4h4"
+					i.ssrURL = ts.URL
+					i.ssrHTTPClient = ts.Client()
+				})
+
+				successRunner(t, i)
+			})
+
+			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				t.Parallel()
 
 				ts := newTestServerSSR(t)
@@ -177,25 +177,25 @@ func TestInertia_Render(t *testing.T) {
 				successRunner(t, i)
 			})
 
-			// t.Run("error with fallback", func(t *testing.T) {
-			// 	t.Parallel()
-			//
-			// 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// 		w.WriteHeader(http.StatusInternalServerError)
-			// 	}))
-			// 	defer ts.Close()
-			//
-			// 	i := I(func(i *Inertia) {
-			// 		i.rootTemplateHTML = rootTemplate
-			// 		i.version = "f8v01xv4h4"
-			// 		i.ssrURL = ts.URL
-			// 		i.ssrHTTPClient = ts.Client()
-			// 	})
-			//
-			// 	errorRunner(t, i)
-			// })
-
 			t.Run("error with fallback", func(t *testing.T) {
+				t.Parallel()
+
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+				defer ts.Close()
+
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = rootTemplate
+					i.version = "f8v01xv4h4"
+					i.ssrURL = ts.URL
+					i.ssrHTTPClient = ts.Client()
+				})
+
+				errorRunner(t, i)
+			})
+
+			t.Run("error with fallback and pre-parsed root template", func(t *testing.T) {
 				t.Parallel()
 
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -241,18 +241,18 @@ func TestInertia_Render(t *testing.T) {
 				}
 			}
 
-			// t.Run("success", func(t *testing.T) {
-			// 	i := I(func(i *Inertia) {
-			// 		i.rootTemplateHTML = `{{ trim " foo bar " }}`
-			// 		i.sharedTemplateFuncs = TemplateFuncs{
-			// 			"trim": strings.TrimSpace,
-			// 		}
-			// 	})
-			//
-			// 	runner(t, i)
-			// })
-
 			t.Run("success", func(t *testing.T) {
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = `{{ trim " foo bar " }}`
+					i.sharedTemplateFuncs = TemplateFuncs{
+						"trim": strings.TrimSpace,
+					}
+				})
+
+				runner(t, i)
+			})
+
+			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				tFuncs := make(TemplateFuncs)
 				tFuncs["trim"] = strings.TrimSpace
 
@@ -291,18 +291,18 @@ func TestInertia_Render(t *testing.T) {
 				}
 			}
 
-			// t.Run("success", func(t *testing.T) {
-			// 	i := I(func(i *Inertia) {
-			// 		i.rootTemplateHTML = `Hello, {{ .text }}!`
-			// 		i.sharedTemplateData = TemplateData{
-			// 			"text": "world",
-			// 		}
-			// 	})
-			//
-			// 	runner(t, i)
-			// })
-
 			t.Run("success", func(t *testing.T) {
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = `Hello, {{ .text }}!`
+					i.sharedTemplateData = TemplateData{
+						"text": "world",
+					}
+				})
+
+				runner(t, i)
+			})
+
+			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				tmpl, err := template.New("root").
 					Funcs(template.FuncMap(make(TemplateFuncs))).
 					Parse(`Hello, {{ .text }}!`)

--- a/response_test.go
+++ b/response_test.go
@@ -38,7 +38,6 @@ func TestInertia_Render(t *testing.T) {
 			tmpl, err := template.New("root").
 				Funcs(template.FuncMap(make(TemplateFuncs))).
 				Parse(rootTemplate)
-
 			if err != nil {
 				t.Fatalf("parse root template: %v", err)
 			}
@@ -55,6 +54,7 @@ func TestInertia_Render(t *testing.T) {
 			t.Parallel()
 
 			newTestServerSSR := func(t *testing.T) *httptest.Server {
+				t.Helper()
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					reqContentType := r.Header.Get("Content-Type")
 					wantContentType := "application/json"
@@ -93,6 +93,7 @@ func TestInertia_Render(t *testing.T) {
 			}
 
 			successRunner := func(t *testing.T, i *Inertia) {
+				t.Helper()
 				w, r := requestMock(http.MethodGet, "/home")
 
 				err := i.Render(w, r, "Some/Component", Props{"foo": "bar"})
@@ -118,6 +119,7 @@ func TestInertia_Render(t *testing.T) {
 			}
 
 			errorRunner := func(t *testing.T, i *Inertia) {
+				t.Helper()
 				w, r := requestMock(http.MethodGet, "/home")
 
 				err := i.Render(w, r, "Some/Component", Props{"foo": "bar"})
@@ -161,7 +163,6 @@ func TestInertia_Render(t *testing.T) {
 				tmpl, err := template.New("root").
 					Funcs(template.FuncMap(make(TemplateFuncs))).
 					Parse(rootTemplate)
-
 				if err != nil {
 					t.Fatalf("parse root template: %v", err)
 				}
@@ -205,7 +206,6 @@ func TestInertia_Render(t *testing.T) {
 				tmpl, err := template.New("root").
 					Funcs(template.FuncMap(make(TemplateFuncs))).
 					Parse(rootTemplate)
-
 				if err != nil {
 					t.Fatalf("parse root template: %v", err)
 				}
@@ -225,6 +225,7 @@ func TestInertia_Render(t *testing.T) {
 			t.Parallel()
 
 			runner := func(t *testing.T, i *Inertia) {
+				t.Helper()
 				w, r := requestMock(http.MethodGet, "/")
 
 				err := i.Render(w, r, "Some/Component")
@@ -258,7 +259,6 @@ func TestInertia_Render(t *testing.T) {
 				tmpl, err := template.New("root").
 					Funcs(template.FuncMap(tFuncs)).
 					Parse(`{{ trim " foo bar " }}`)
-
 				if err != nil {
 					t.Fatalf("parse root template: %v", err)
 				}
@@ -275,6 +275,7 @@ func TestInertia_Render(t *testing.T) {
 			t.Parallel()
 
 			runner := func(t *testing.T, i *Inertia) {
+				t.Helper()
 				w, r := requestMock(http.MethodGet, "/")
 
 				err := i.Render(w, r, "Some/Component")
@@ -305,7 +306,6 @@ func TestInertia_Render(t *testing.T) {
 				tmpl, err := template.New("root").
 					Funcs(template.FuncMap(make(TemplateFuncs))).
 					Parse(`Hello, {{ .text }}!`)
-
 				if err != nil {
 					t.Fatalf("parse root template: %v", err)
 				}

--- a/response_test.go
+++ b/response_test.go
@@ -21,18 +21,18 @@ func TestInertia_Render(t *testing.T) {
 	t.Run("plain request", func(t *testing.T) {
 		t.Parallel()
 
+		// t.Run("success", func(t *testing.T) {
+		// 	t.Parallel()
+		//
+		// 	i := I(func(i *Inertia) {
+		// 		i.rootTemplateHTML = rootTemplate
+		// 		i.version = "f8v01xv4h4"
+		// 	})
+		//
+		// 	assertRootTemplateSuccess(t, i)
+		// })
+
 		t.Run("success", func(t *testing.T) {
-			t.Parallel()
-
-			i := I(func(i *Inertia) {
-				i.rootTemplateHTML = rootTemplate
-				i.version = "f8v01xv4h4"
-			})
-
-			assertRootTemplateSuccess(t, i)
-		})
-
-		t.Run("success with pre-parsed template", func(t *testing.T) {
 			t.Parallel()
 
 			tmpl, err := template.New("root").
@@ -136,24 +136,24 @@ func TestInertia_Render(t *testing.T) {
 				assertable.AssertURL("/home")
 			}
 
+			// t.Run("success", func(t *testing.T) {
+			// 	t.Parallel()
+			//
+			// 	ts := newTestServerSSR(t)
+			//
+			// 	defer ts.Close()
+			//
+			// 	i := I(func(i *Inertia) {
+			// 		i.rootTemplateHTML = rootTemplate
+			// 		i.version = "f8v01xv4h4"
+			// 		i.ssrURL = ts.URL
+			// 		i.ssrHTTPClient = ts.Client()
+			// 	})
+			//
+			// 	successRunner(t, i)
+			// })
+
 			t.Run("success", func(t *testing.T) {
-				t.Parallel()
-
-				ts := newTestServerSSR(t)
-
-				defer ts.Close()
-
-				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = rootTemplate
-					i.version = "f8v01xv4h4"
-					i.ssrURL = ts.URL
-					i.ssrHTTPClient = ts.Client()
-				})
-
-				successRunner(t, i)
-			})
-
-			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				t.Parallel()
 
 				ts := newTestServerSSR(t)
@@ -177,25 +177,25 @@ func TestInertia_Render(t *testing.T) {
 				successRunner(t, i)
 			})
 
+			// t.Run("error with fallback", func(t *testing.T) {
+			// 	t.Parallel()
+			//
+			// 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// 		w.WriteHeader(http.StatusInternalServerError)
+			// 	}))
+			// 	defer ts.Close()
+			//
+			// 	i := I(func(i *Inertia) {
+			// 		i.rootTemplateHTML = rootTemplate
+			// 		i.version = "f8v01xv4h4"
+			// 		i.ssrURL = ts.URL
+			// 		i.ssrHTTPClient = ts.Client()
+			// 	})
+			//
+			// 	errorRunner(t, i)
+			// })
+
 			t.Run("error with fallback", func(t *testing.T) {
-				t.Parallel()
-
-				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
-				defer ts.Close()
-
-				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = rootTemplate
-					i.version = "f8v01xv4h4"
-					i.ssrURL = ts.URL
-					i.ssrHTTPClient = ts.Client()
-				})
-
-				errorRunner(t, i)
-			})
-
-			t.Run("error with fallback and pre-parsed root template", func(t *testing.T) {
 				t.Parallel()
 
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -241,18 +241,18 @@ func TestInertia_Render(t *testing.T) {
 				}
 			}
 
+			// t.Run("success", func(t *testing.T) {
+			// 	i := I(func(i *Inertia) {
+			// 		i.rootTemplateHTML = `{{ trim " foo bar " }}`
+			// 		i.sharedTemplateFuncs = TemplateFuncs{
+			// 			"trim": strings.TrimSpace,
+			// 		}
+			// 	})
+			//
+			// 	runner(t, i)
+			// })
+
 			t.Run("success", func(t *testing.T) {
-				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = `{{ trim " foo bar " }}`
-					i.sharedTemplateFuncs = TemplateFuncs{
-						"trim": strings.TrimSpace,
-					}
-				})
-
-				runner(t, i)
-			})
-
-			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				tFuncs := make(TemplateFuncs)
 				tFuncs["trim"] = strings.TrimSpace
 
@@ -291,18 +291,18 @@ func TestInertia_Render(t *testing.T) {
 				}
 			}
 
+			// t.Run("success", func(t *testing.T) {
+			// 	i := I(func(i *Inertia) {
+			// 		i.rootTemplateHTML = `Hello, {{ .text }}!`
+			// 		i.sharedTemplateData = TemplateData{
+			// 			"text": "world",
+			// 		}
+			// 	})
+			//
+			// 	runner(t, i)
+			// })
+
 			t.Run("success", func(t *testing.T) {
-				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = `Hello, {{ .text }}!`
-					i.sharedTemplateData = TemplateData{
-						"text": "world",
-					}
-				})
-
-				runner(t, i)
-			})
-
-			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				tmpl, err := template.New("root").
 					Funcs(template.FuncMap(make(TemplateFuncs))).
 					Parse(`Hello, {{ .text }}!`)

--- a/response_test.go
+++ b/response_test.go
@@ -32,13 +32,30 @@ func TestInertia_Render(t *testing.T) {
 			assertRootTemplateSuccess(t, i)
 		})
 
+		t.Run("success with pre-parsed template", func(t *testing.T) {
+			t.Parallel()
+
+			tmpl, err := template.New("root").
+				Funcs(template.FuncMap(make(TemplateFuncs))).
+				Parse(rootTemplate)
+
+			if err != nil {
+				t.Fatalf("parse root template: %v", err)
+			}
+
+			i := I(func(i *Inertia) {
+				i.rootTemplate = tmpl
+				i.version = "f8v01xv4h4"
+			})
+
+			assertRootTemplateSuccess(t, i)
+		})
+
 		t.Run("ssr", func(t *testing.T) {
 			t.Parallel()
 
-			t.Run("success", func(t *testing.T) {
-				t.Parallel()
-
-				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			newTestServerSSR := func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					reqContentType := r.Header.Get("Content-Type")
 					wantContentType := "application/json"
 					if reqContentType != wantContentType {
@@ -73,15 +90,9 @@ func TestInertia_Render(t *testing.T) {
 						t.Fatalf("unexpected error: %s", err)
 					}
 				}))
-				defer ts.Close()
+			}
 
-				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = rootTemplate
-					i.version = "f8v01xv4h4"
-					i.ssrURL = ts.URL
-					i.ssrHTTPClient = ts.Client()
-				})
-
+			successRunner := func(t *testing.T, i *Inertia) {
 				w, r := requestMock(http.MethodGet, "/home")
 
 				err := i.Render(w, r, "Some/Component", Props{"foo": "bar"})
@@ -104,6 +115,65 @@ func TestInertia_Render(t *testing.T) {
 				if got != want {
 					t.Fatalf("got content=%s, want=%s", got, want)
 				}
+			}
+
+			errorRunner := func(t *testing.T, i *Inertia) {
+				w, r := requestMock(http.MethodGet, "/home")
+
+				err := i.Render(w, r, "Some/Component", Props{"foo": "bar"})
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				var buf bytes.Buffer
+
+				assertable := AssertFromReader(t, io.TeeReader(w.Body, &buf))
+				assertable.AssertComponent("Some/Component")
+				assertable.AssertProps(Props{"foo": "bar", "errors": map[string]any{}})
+				assertable.AssertVersion("f8v01xv4h4")
+				assertable.AssertURL("/home")
+			}
+
+			t.Run("success", func(t *testing.T) {
+				t.Parallel()
+
+				ts := newTestServerSSR(t)
+
+				defer ts.Close()
+
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = rootTemplate
+					i.version = "f8v01xv4h4"
+					i.ssrURL = ts.URL
+					i.ssrHTTPClient = ts.Client()
+				})
+
+				successRunner(t, i)
+			})
+
+			t.Run("success with pre-parsed root template", func(t *testing.T) {
+				t.Parallel()
+
+				ts := newTestServerSSR(t)
+
+				defer ts.Close()
+
+				tmpl, err := template.New("root").
+					Funcs(template.FuncMap(make(TemplateFuncs))).
+					Parse(rootTemplate)
+
+				if err != nil {
+					t.Fatalf("parse root template: %v", err)
+				}
+
+				i := I(func(i *Inertia) {
+					i.rootTemplate = tmpl
+					i.version = "f8v01xv4h4"
+					i.ssrURL = ts.URL
+					i.ssrHTTPClient = ts.Client()
+				})
+
+				successRunner(t, i)
 			})
 
 			t.Run("error with fallback", func(t *testing.T) {
@@ -121,71 +191,134 @@ func TestInertia_Render(t *testing.T) {
 					i.ssrHTTPClient = ts.Client()
 				})
 
-				w, r := requestMock(http.MethodGet, "/home")
+				errorRunner(t, i)
+			})
 
-				err := i.Render(w, r, "Some/Component", Props{"foo": "bar"})
+			t.Run("error with fallback and pre-parsed root template", func(t *testing.T) {
+				t.Parallel()
+
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+				defer ts.Close()
+
+				tmpl, err := template.New("root").
+					Funcs(template.FuncMap(make(TemplateFuncs))).
+					Parse(rootTemplate)
+
 				if err != nil {
-					t.Fatalf("unexpected error: %s", err)
+					t.Fatalf("parse root template: %v", err)
 				}
 
-				var buf bytes.Buffer
+				i := I(func(i *Inertia) {
+					i.rootTemplate = tmpl
+					i.version = "f8v01xv4h4"
+					i.ssrURL = ts.URL
+					i.ssrHTTPClient = ts.Client()
+				})
 
-				assertable := AssertFromReader(t, io.TeeReader(w.Body, &buf))
-				assertable.AssertComponent("Some/Component")
-				assertable.AssertProps(Props{"foo": "bar", "errors": map[string]any{}})
-				assertable.AssertVersion("f8v01xv4h4")
-				assertable.AssertURL("/home")
+				errorRunner(t, i)
 			})
 		})
 
 		t.Run("shared funcs", func(t *testing.T) {
 			t.Parallel()
 
-			w, r := requestMock(http.MethodGet, "/")
+			runner := func(t *testing.T, i *Inertia) {
+				w, r := requestMock(http.MethodGet, "/")
 
-			i := I(func(i *Inertia) {
-				i.rootTemplateHTML = `{{ trim " foo bar " }}`
-				i.sharedTemplateFuncs = TemplateFuncs{
-					"trim": strings.TrimSpace,
+				err := i.Render(w, r, "Some/Component")
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
 				}
+
+				got := w.Body.String()
+				want := "foo bar"
+
+				if got != want {
+					t.Fatalf("got=%s, want=%s", got, want)
+				}
+			}
+
+			t.Run("success", func(t *testing.T) {
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = `{{ trim " foo bar " }}`
+					i.sharedTemplateFuncs = TemplateFuncs{
+						"trim": strings.TrimSpace,
+					}
+				})
+
+				runner(t, i)
 			})
 
-			err := i.Render(w, r, "Some/Component")
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
+			t.Run("success with pre-parsed root template", func(t *testing.T) {
+				tFuncs := make(TemplateFuncs)
+				tFuncs["trim"] = strings.TrimSpace
 
-			got := w.Body.String()
-			want := "foo bar"
+				tmpl, err := template.New("root").
+					Funcs(template.FuncMap(tFuncs)).
+					Parse(`{{ trim " foo bar " }}`)
 
-			if got != want {
-				t.Fatalf("got=%s, want=%s", got, want)
-			}
+				if err != nil {
+					t.Fatalf("parse root template: %v", err)
+				}
+
+				i := I(func(i *Inertia) {
+					i.rootTemplate = tmpl
+				})
+
+				runner(t, i)
+			})
 		})
 
 		t.Run("shared template data", func(t *testing.T) {
 			t.Parallel()
 
-			w, r := requestMock(http.MethodGet, "/")
+			runner := func(t *testing.T, i *Inertia) {
+				w, r := requestMock(http.MethodGet, "/")
 
-			i := I(func(i *Inertia) {
-				i.rootTemplateHTML = `Hello, {{ .text }}!`
-				i.sharedTemplateData = TemplateData{
-					"text": "world",
+				err := i.Render(w, r, "Some/Component")
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
 				}
+
+				got := w.Body.String()
+				want := "Hello, world!"
+
+				if got != want {
+					t.Fatalf("got=%s, want=%s", got, want)
+				}
+			}
+
+			t.Run("success", func(t *testing.T) {
+				i := I(func(i *Inertia) {
+					i.rootTemplateHTML = `Hello, {{ .text }}!`
+					i.sharedTemplateData = TemplateData{
+						"text": "world",
+					}
+				})
+
+				runner(t, i)
 			})
 
-			err := i.Render(w, r, "Some/Component")
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
+			t.Run("success with pre-parsed root template", func(t *testing.T) {
+				tmpl, err := template.New("root").
+					Funcs(template.FuncMap(make(TemplateFuncs))).
+					Parse(`Hello, {{ .text }}!`)
 
-			got := w.Body.String()
-			want := "Hello, world!"
+				if err != nil {
+					t.Fatalf("parse root template: %v", err)
+				}
 
-			if got != want {
-				t.Fatalf("got=%s, want=%s", got, want)
-			}
+				i := I(func(i *Inertia) {
+					i.rootTemplate = tmpl
+					i.sharedTemplateData = TemplateData{
+						"text": "world",
+					}
+				})
+
+				runner(t, i)
+			})
 		})
 	})
 
@@ -200,11 +333,10 @@ func TestInertia_Render(t *testing.T) {
 			})
 
 			w, r := requestMock(http.MethodGet, "/home")
+
 			asInertiaRequest(r)
 
-			err := i.Render(w, r, "Some/Component", Props{
-				"foo": "bar",
-			})
+			err := i.Render(w, r, "Some/Component", Props{"foo": "bar"})
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -216,7 +348,6 @@ func TestInertia_Render(t *testing.T) {
 			assertable.AssertURL("/home")
 			assertable.AssertEncryptHistory(false)
 			assertable.AssertEncryptHistory(false)
-
 			assertInertiaResponse(t, w)
 			assertJSONResponse(t, w)
 			assertResponseStatusCode(t, w, http.StatusOK)


### PR DESCRIPTION
This PR addresses the feature request to enhance the Gonertia library with a new constructor that supports initializing an `Inertia` instance using a parsed `*template.Template`.

## **Problem**

Currently, the library requires a `rootTemplateHTML` field to create an `Inertia` instance, which limits flexibility for projects that already use parsed templates. 

## **Solution**

A new constructor method is introduced:

```go
func NewFromTemplate(t *template.Template, opts ...Option) (*Inertia, error)
```

This allows direct initialization with a parsed template, leveraging the existing `rootTemplate` logic in the `doHTMLResponse` method.

## **Changes Made**

- Added the `NewFromTemplate` constructor.
- Updated logic to ensure compatibility with the existing codebase.
- Wrote unit tests to validate the new functionality.

## **Benefits**

- Integrates smoothly with existing template parsing workflows.
- Reduces redundant template parsing for projects with pre-parsed templates.
- Provides a cleaner and more flexible API for initializing `Inertia`.

## **Example**

```go
tmpl := template.Must(template.ParseFiles("layout.html", "components.html"))
inertia, err := NewFromTemplate(tmpl, 
    WithSharedProps(props),
    WithVersion("1.0")
)
```

## **References**

- Closes [#26](https://github.com/romsar/gonertia/issues/26)

## **Next Steps**

Feedback on the implementation and additional edge cases is welcome. I am happy to address any review comments to ensure this aligns with the library's standards.
