### PR TITLE
refactor: phase out lazy template parsing

### DIFF
--- a/response.go
+++ b/response.go
@@ -445,14 +445,6 @@ func (i *Inertia) doInertiaResponse(w http.ResponseWriter, page *page) error {
 }
 
 func (i *Inertia) doHTMLResponse(w http.ResponseWriter, r *http.Request, page *page) (err error) {
-	// If root template is already created - we'll use it to save some time.
-	if i.rootTemplate == nil {
-		i.rootTemplate, err = i.buildRootTemplate()
-		if err != nil {
-			return fmt.Errorf("build root template: %w", err)
-		}
-	}
-
 	templateData, err := i.buildTemplateData(r, page)
 	if err != nil {
 		return fmt.Errorf("build template data: %w", err)
@@ -465,11 +457,6 @@ func (i *Inertia) doHTMLResponse(w http.ResponseWriter, r *http.Request, page *p
 	}
 
 	return nil
-}
-
-func (i *Inertia) buildRootTemplate() (*template.Template, error) {
-	tmpl := template.New("").Funcs(template.FuncMap(i.sharedTemplateFuncs))
-	return tmpl.Parse(i.rootTemplateHTML)
 }
 
 func (i *Inertia) buildTemplateData(r *http.Request, page *page) (TemplateData, error) {

--- a/response_test.go
+++ b/response_test.go
@@ -24,26 +24,13 @@ func TestInertia_Render(t *testing.T) {
 		t.Run("success", func(t *testing.T) {
 			t.Parallel()
 
-			i := I(func(i *Inertia) {
-				i.rootTemplateHTML = rootTemplate
-				i.version = "f8v01xv4h4"
-			})
-
-			assertRootTemplateSuccess(t, i)
-		})
-
-		t.Run("success with pre-parsed template", func(t *testing.T) {
-			t.Parallel()
-
-			tmpl, err := template.New("root").
-				Funcs(template.FuncMap(make(TemplateFuncs))).
-				Parse(rootTemplate)
+			root, err := template.New("root").Parse(rootTemplate)
 			if err != nil {
 				t.Fatalf("parse root template: %v", err)
 			}
 
 			i := I(func(i *Inertia) {
-				i.rootTemplate = tmpl
+				i.rootTemplate = root
 				i.version = "f8v01xv4h4"
 			})
 
@@ -143,8 +130,13 @@ func TestInertia_Render(t *testing.T) {
 
 				defer ts.Close()
 
+				root, err := template.New("root").Parse(rootTemplate)
+				if err != nil {
+					t.Fatalf("parse root template: %v", err)
+				}
+
 				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = rootTemplate
+					i.rootTemplate = root
 					i.version = "f8v01xv4h4"
 					i.ssrURL = ts.URL
 					i.ssrHTTPClient = ts.Client()
@@ -185,8 +177,13 @@ func TestInertia_Render(t *testing.T) {
 				}))
 				defer ts.Close()
 
+				root, err := template.New("root").Parse(rootTemplate)
+				if err != nil {
+					t.Fatalf("parse root template: %v", err)
+				}
+
 				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = rootTemplate
+					i.rootTemplate = root
 					i.version = "f8v01xv4h4"
 					i.ssrURL = ts.URL
 					i.ssrHTTPClient = ts.Client()
@@ -242,17 +239,6 @@ func TestInertia_Render(t *testing.T) {
 			}
 
 			t.Run("success", func(t *testing.T) {
-				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = `{{ trim " foo bar " }}`
-					i.sharedTemplateFuncs = TemplateFuncs{
-						"trim": strings.TrimSpace,
-					}
-				})
-
-				runner(t, i)
-			})
-
-			t.Run("success with pre-parsed root template", func(t *testing.T) {
 				tFuncs := make(TemplateFuncs)
 				tFuncs["trim"] = strings.TrimSpace
 
@@ -291,9 +277,14 @@ func TestInertia_Render(t *testing.T) {
 				}
 			}
 
+			root, err := template.New("root").Parse(`Hello, {{ .text }}!`)
+			if err != nil {
+				t.Fatalf("parse root template: %v", err)
+			}
+
 			t.Run("success", func(t *testing.T) {
 				i := I(func(i *Inertia) {
-					i.rootTemplateHTML = `Hello, {{ .text }}!`
+					i.rootTemplate = root
 					i.sharedTemplateData = TemplateData{
 						"text": "world",
 					}


### PR DESCRIPTION


# Refactor: Simplify Template Initialization in Gonertia

## Overview
This PR addresses #28 (issue previously discussed in #27) by improving template handling in the Gonertia library.

- Eliminating lazy template parsing
- Removing `rootTemplateHTML` field from `Inertia` struct
- Introducing optional `funcMap` parameter in constructors
- Simplifying template initialization logic

## Key Changes
- Eager template parsing across all constructors
- Removed `ShareTemplateFunc` method
- Standardized template creation process
- Updated test suite to reflect new implementation

## Motivation
The refactoring aims to:
- Improve code clarity
- Reduce complexity in template management
- Provide more explicit template initialization
- Remove unnecessary state tracking

## Breaking Changes
- Constructors now require explicit template parsing
- Removed `ShareTemplateFunc` method