### PR TITLE
Add Support for fs.FS with NewFromFileFS and WithVersionFromFileFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import (
 func main() {
     i, err := inertia.New(rootHTMLString)
     // i, err := inertia.NewFromFile("resources/views/root.html")
+    // i, err := inertia.NewFromFileFS(embedFS, "resources/views/root.html")
     // i, err := inertia.NewFromReader(rootHTMLReader)
     // i, err := inertia.NewFromBytes(rootHTMLBytes)
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ i, err := inertia.New(
     /* ... */
     inertia.WithVersion("some-version"), // by any string
     inertia.WithVersionFromFile("./public/build/manifest.json"), // by file checksum
+    inertia.WithVersionFromFileFS(embedFS, "./public/build/manifest.json"), // by file checksum from fs.FS
 )
 ```
 

--- a/inertia.go
+++ b/inertia.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -54,6 +55,16 @@ func New(rootTemplateHTML string, opts ...Option) (*Inertia, error) {
 	}
 
 	return i, nil
+}
+
+// NewFromFileFS reads all bytes from the root template file and then initializes Inertia.
+func NewFromFileFS(rootFS fs.FS, rootTemplatePath string, opts ...Option) (*Inertia, error) {
+	bs, err := fs.ReadFile(rootFS, rootTemplatePath)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", rootTemplatePath, err)
+	}
+
+	return NewFromBytes(bs, opts...)
 }
 
 // NewFromFile reads all bytes from the root template file and then initializes Inertia.

--- a/inertia_test.go
+++ b/inertia_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 var rootTemplate = `<html>
@@ -44,6 +45,25 @@ func TestNewFromFile(t *testing.T) {
 	f := tmpFile(t, rootTemplate)
 
 	i, err := NewFromFile(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if i.rootTemplateHTML != rootTemplate {
+		t.Fatalf("root template html=%s, want=%s", i.rootTemplateHTML, rootTemplate)
+	}
+}
+
+func TestNewFromFileFS(t *testing.T) {
+	t.Parallel()
+
+	testFS := fstest.MapFS{
+		"root.html": {
+			Data: []byte(rootTemplate),
+		},
+	}
+
+	i, err := NewFromFileFS(testFS, "root.html")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/option.go
+++ b/option.go
@@ -3,6 +3,7 @@ package gonertia
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 )
@@ -14,6 +15,18 @@ type Option func(i *Inertia) error
 func WithVersion(version string) Option {
 	return func(i *Inertia) error {
 		i.version = md5(version)
+		return nil
+	}
+}
+
+// WithVersionFromFileFS returns Option that will set Inertia's version based on file checksum from rootFS.
+func WithVersionFromFileFS(rootFS fs.FS, path string) Option {
+	return func(i *Inertia) (err error) {
+		i.version, err = md5FileFromFS(rootFS, path)
+		if err != nil {
+			return fmt.Errorf("calculating md5 hash of manifest file: %w", err)
+		}
+
 		return nil
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"reflect"
 	"testing"
+	"testing/fstest"
 )
 
 func TestWithVersion(t *testing.T) {
@@ -33,6 +34,30 @@ func TestWithVersionFromFile(t *testing.T) {
 	f := tmpFile(t, "foo")
 
 	option := WithVersionFromFile(f.Name())
+
+	want := "acbd18db4cc2f85cedef654fccc4a4d8"
+
+	if err := option(i); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if i.version != want {
+		t.Fatalf("version=%s, want=%s", i.version, want)
+	}
+}
+
+func TestWithVersionFromFileFS(t *testing.T) {
+	t.Parallel()
+
+	i := I()
+
+	mapFS := fstest.MapFS{
+		"foo": {
+			Data: []byte("foo"),
+		},
+	}
+
+	option := WithVersionFromFileFS(mapFS, "foo")
 
 	want := "acbd18db4cc2f85cedef654fccc4a4d8"
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package gonertia
 import (
 	"reflect"
 	"testing"
+	"testing/fstest"
 )
 
 func Test_setOf(t *testing.T) {
@@ -155,5 +156,24 @@ func Test_md5File(t *testing.T) {
 
 	if want := md5("foo"); got != want {
 		t.Fatalf("md5File()=%s, want=%s", got, want)
+	}
+}
+
+func Test_md5FileFromFS(t *testing.T) {
+	t.Parallel()
+
+	testFS := fstest.MapFS{
+		"foo": {
+			Data: []byte("foo"),
+		},
+	}
+
+	got, err := md5FileFromFS(testFS, "foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want := md5("foo"); got != want {
+		t.Fatalf("md5FileFromFS()=%s, want=%s", got, want)
 	}
 }


### PR DESCRIPTION
This pull request adds equivalent functions to `NewFromFile` and `WithVersionFromFile` to support the `fs.FS` interface.
It also includes unit tests to ensure these functions work as expected.

Let me know if further refinements are needed!