### PR TITLE
feat: add assets management

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,13 +485,65 @@ Create your root template with Vite functions:
 </html>
 ```
 
+#### Vite Asset Management
+
+Automatic asset loading with configurable preload strategies:
+
+```go
+app, err := inertia.NewVite(i,
+    inertia.WithEntryPoints("resources/js/app.tsx"),
+    inertia.WithAutoNonce(),
+    inertia.WithWaterfallPreload(3),
+)
+```
+
+**Template usage - Two approaches:**
+
+**Option 1: Config-based**
+```html
+<head>
+    {{ .inertiaHead }}
+    {{ viteAssets }}
+</head>
+```
+
+**Option 2: Template arguments**
+```html
+<head>
+    {{ .inertiaHead }}
+    {{ viteAssets "resources/js/app.tsx" }}
+    {{ viteAssets "app.js" "admin.js" }}
+</head>
+```
+
+**Configuration options:**
+- `WithEntryPoints(...)` - Specify entry points (required unless using template args)
+- `WithNonce(nonce)` - Set static CSP nonce
+- `WithAutoNonce()` - Auto-generate crypto nonce
+- `WithNonceGenerator(fn)` - Custom nonce generator
+- `WithIntegrity()` - Enable SubResource Integrity (requires Vite plugin like [vite-plugin-manifest-sri](https://github.com/ElMassimo/vite-plugin-manifest-sri))
+
+**Preload strategies:**
+- `WithoutPreloading()` - Minimal output, browser handles discovery (default)
+- `WithAggressivePreload()` - Preload all dependencies immediately
+- `WithWaterfallPreload(concurrent)` - Batched prefetch with concurrency control
+
+**SubResource Integrity (SRI):**
+
+SRI hashes are automatically included in generated tags when present in the manifest. To add SRI support to your Vite build:
+
+1. Install [vite-plugin-manifest-sri](https://github.com/ElMassimo/vite-plugin-manifest-sri)
+2. Add the plugin to your `vite.config.js`
+3. The `integrity` field will be read from the manifest and added to all asset tags
+
 #### Template functions
 
 The Vite integration provides the following template functions:
 
-- **`{{ vite "path" }}`** - Resolves asset URLs automatically (dev vs production)
-- **`{{ viteRefresh }}`** - Generic HMR setup for frameworks like Preact, Vue, or custom setups
-- **`{{ viteReactRefresh }}`** - React-specific HMR with refresh runtime injection
+- **`{{ viteAssets "entry.js" ... }}`** - Outputs all required assets (accepts optional entry point args)
+- **`{{ vite "path" }}`** - Resolves asset URLs (dev vs production)
+- **`{{ viteRefresh }}`** - HMR setup for frameworks like Preact, Vue
+- **`{{ viteReactRefresh }}`** - React-specific HMR with refresh runtime
 
 #### Testing
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,6 @@ Automatic asset loading with configurable preload strategies:
 ```go
 app, err := inertia.NewVite(i,
     inertia.WithEntryPoints("resources/js/app.tsx"),
-    inertia.WithAutoNonce(),
     inertia.WithWaterfallPreload(3),
 )
 ```
@@ -518,9 +517,6 @@ app, err := inertia.NewVite(i,
 
 **Configuration options:**
 - `WithEntryPoints(...)` - Specify entry points (required unless using template args)
-- `WithNonce(nonce)` - Set static CSP nonce
-- `WithAutoNonce()` - Auto-generate crypto nonce
-- `WithNonceGenerator(fn)` - Custom nonce generator
 - `WithIntegrity()` - Enable SubResource Integrity (requires Vite plugin like [vite-plugin-manifest-sri](https://github.com/ElMassimo/vite-plugin-manifest-sri))
 
 **Preload strategies:**
@@ -536,11 +532,33 @@ SRI hashes are automatically included in generated tags when present in the mani
 2. Add the plugin to your `vite.config.js`
 3. The `integrity` field will be read from the manifest and added to all asset tags
 
+#### Content Security Policy (CSP)
+
+```go
+handler := app.CSPMiddleware()(app.Middleware(mux))
+```
+
+Template:
+```html
+{{ viteAssetsWithNonce .csp_nonce "app.tsx" }}
+```
+
+Customize:
+```go
+app.CSPMiddleware(
+    inertia.WithCSPPolicy("script-src 'nonce-%s'"),
+    inertia.WithCSPNonceGenerator(customFunc),
+)
+```
+
+Returns `func(http.Handler) http.Handler`. Nonces applied to all tags. Merges with existing CSP headers.
+
 #### Template functions
 
 The Vite integration provides the following template functions:
 
 - **`{{ viteAssets "entry.js" ... }}`** - Outputs all required assets (accepts optional entry point args)
+- **`{{ viteAssetsWithNonce .csp_nonce "entry.js" ... }}`** - Outputs assets with CSP nonce for enhanced security
 - **`{{ vite "path" }}`** - Resolves asset URLs (dev vs production)
 - **`{{ viteRefresh }}`** - HMR setup for frameworks like Preact, Vue
 - **`{{ viteReactRefresh }}`** - React-specific HMR with refresh runtime

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Template:
 Customize:
 ```go
 app.CSPMiddleware(
-    inertia.WithCSPPolicy("script-src 'nonce-%s'"),
+    inertia.WithCSPPolicy("script-src 'nonce-{{nonce}}'"),
     inertia.WithCSPNonceGenerator(customFunc),
 )
 ```

--- a/vite.go
+++ b/vite.go
@@ -2,6 +2,8 @@
 package gonertia
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -10,6 +12,21 @@ import (
 	"path"
 	"strings"
 )
+
+// PreloadStrategy determines how dependencies are loaded.
+type PreloadStrategy string
+
+const (
+	// PreloadNone loads only the main entry point with no preloading.
+	PreloadNone PreloadStrategy = "none"
+	// PreloadAggressive preloads all static dependencies immediately.
+	PreloadAggressive PreloadStrategy = "aggressive"
+	// PreloadWaterfall loads dependencies in controlled batches after page load.
+	PreloadWaterfall PreloadStrategy = "waterfall"
+)
+
+// NonceGenerator generates CSP nonces.
+type NonceGenerator func() string
 
 // ViteConfig holds Vite configuration.
 type ViteConfig struct {
@@ -20,6 +37,14 @@ type ViteConfig struct {
 	HotReloadPort    string
 	EmbedFS          fs.FS // Optional fs.FS (embed.FS or os.DirFS) for production builds
 	UseEmbedFS       bool  // Whether to use embed.FS for manifest loading
+
+	// Asset management configuration
+	Nonce             string          // Static CSP nonce
+	NonceGenerator    NonceGenerator  // Dynamic nonce generator (called once)
+	IntegrityKey      *string         // Manifest key for SRI hashes (nil = disabled)
+	EntryPoints       []string        // Entry points for asset generation
+	PreloadStrategy   PreloadStrategy // How to handle dependency loading
+	PreloadConcurrent int             // Concurrent prefetch count for waterfall
 }
 
 // ViteInstance wraps Inertia with Vite functionality.
@@ -66,6 +91,86 @@ func WithHotReloadPort(port string) ViteOption {
 	}
 }
 
+// WithNonce sets a static CSP nonce.
+func WithNonce(nonce string) ViteOption {
+	return func(c *ViteConfig) {
+		c.Nonce = nonce
+	}
+}
+
+// WithAutoNonce generates a cryptographically secure nonce automatically.
+func WithAutoNonce() ViteOption {
+	return func(c *ViteConfig) {
+		c.Nonce = generateCryptoNonce()
+	}
+}
+
+// WithNonceGenerator sets a custom nonce generator function.
+func WithNonceGenerator(gen NonceGenerator) ViteOption {
+	return func(c *ViteConfig) {
+		c.NonceGenerator = gen
+	}
+}
+
+// WithIntegrity enables SubResource Integrity with the default manifest key "integrity".
+func WithIntegrity() ViteOption {
+	return func(c *ViteConfig) {
+		key := "integrity"
+		c.IntegrityKey = &key
+	}
+}
+
+// WithIntegrityKey enables SubResource Integrity with a custom manifest key.
+func WithIntegrityKey(key string) ViteOption {
+	return func(c *ViteConfig) {
+		c.IntegrityKey = &key
+	}
+}
+
+// WithEntryPoints explicitly sets entry points to load.
+func WithEntryPoints(entries ...string) ViteOption {
+	return func(c *ViteConfig) {
+		c.EntryPoints = entries
+	}
+}
+
+// WithoutPreloading disables preloading. Browser handles module discovery naturally.
+// This is the default behavior.
+func WithoutPreloading() ViteOption {
+	return withPreloadStrategy(PreloadNone, 0)
+}
+
+// WithAggressivePreload enables aggressive preloading of all dependencies.
+// All JavaScript imports are preloaded immediately using modulepreload.
+func WithAggressivePreload() ViteOption {
+	return withPreloadStrategy(PreloadAggressive, 0)
+}
+
+// WithWaterfallPreload enables batched prefetch with concurrency control.
+// Assets are loaded after page load in batches. concurrent controls how many
+// assets load in parallel (default: 3 if not specified or <= 0).
+func WithWaterfallPreload(concurrent int) ViteOption {
+	return withPreloadStrategy(PreloadWaterfall, concurrent)
+}
+
+// withPreloadStrategy sets the preload strategy and concurrency.
+// This is the internal implementation used by public helpers.
+func withPreloadStrategy(strategy PreloadStrategy, concurrent int) ViteOption {
+	return func(c *ViteConfig) {
+		c.PreloadStrategy = strategy
+		c.PreloadConcurrent = concurrent
+	}
+}
+
+// generateCryptoNonce creates a cryptographically secure random nonce.
+func generateCryptoNonce() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
 // NewVite creates a Vite instance with the given Inertia instance.
 // This uses the file system for hot reload detection and manifest loading.
 func NewVite(i *Inertia, opts ...ViteOption) (*ViteInstance, error) {
@@ -76,6 +181,10 @@ func NewVite(i *Inertia, opts ...ViteOption) (*ViteInstance, error) {
 		BuildDir:         "/build/",
 		HotReloadPort:    "//localhost:5173",
 		UseEmbedFS:       false,
+
+		// Default configuration
+		PreloadStrategy:   PreloadNone,
+		PreloadConcurrent: 3,
 	}
 
 	for _, opt := range opts {
@@ -105,6 +214,10 @@ func NewViteFromFS(i *Inertia, embedFS fs.FS, opts ...ViteOption) (*ViteInstance
 		HotReloadPort:    "//localhost:5173",
 		EmbedFS:          embedFS,
 		UseEmbedFS:       true,
+
+		// Default configuration
+		PreloadStrategy:   PreloadNone,
+		PreloadConcurrent: 3,
 	}
 
 	for _, opt := range opts {
@@ -131,6 +244,7 @@ func NewWithVite(i *Inertia, opts ...ViteOption) (*ViteInstance, error) {
 func (vi *ViteInstance) setup() error {
 	hotReload := vi.isHotReload()
 
+	// Existing template functions (backward compatibility)
 	if err := vi.ShareTemplateFunc("vite", vi.assetResolver(hotReload)); err != nil {
 		return fmt.Errorf("share vite function: %w", err)
 	}
@@ -141,6 +255,10 @@ func (vi *ViteInstance) setup() error {
 
 	if err := vi.ShareTemplateFunc("viteRefresh", vi.refreshHelper(hotReload)); err != nil {
 		return fmt.Errorf("share vite refresh function: %w", err)
+	}
+
+	if err := vi.ShareTemplateFunc("viteAssets", vi.generateAllAssets); err != nil {
+		return fmt.Errorf("share viteAssets function: %w", err)
 	}
 
 	vi.ShareTemplateData("hmr", hotReload)
@@ -323,6 +441,13 @@ func (vi *ViteInstance) findManifest() (string, error) {
 
 // Asset represents a Vite manifest entry.
 type Asset struct {
-	File string `json:"file"`
-	Src  string `json:"src"`
+	File           string   `json:"file"`                     // Hashed output file
+	Src            string   `json:"src,omitempty"`            // Source file path
+	Name           string   `json:"name,omitempty"`           // Asset name
+	IsEntry        bool     `json:"isEntry,omitempty"`        // Main entry point
+	IsDynamicEntry bool     `json:"isDynamicEntry,omitempty"` // Code-split chunk
+	Imports        []string `json:"imports,omitempty"`        // Static dependencies
+	DynamicImports []string `json:"dynamicImports,omitempty"` // Lazy imports
+	Css            []string `json:"css,omitempty"`            // Associated CSS
+	Integrity      string   `json:"integrity,omitempty"`      // SRI hash (e.g., from vite-plugin-manifest-sri)
 }

--- a/vite.go
+++ b/vite.go
@@ -2,8 +2,6 @@
 package gonertia
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -25,9 +23,6 @@ const (
 	PreloadWaterfall PreloadStrategy = "waterfall"
 )
 
-// NonceGenerator generates CSP nonces.
-type NonceGenerator func() string
-
 // ViteConfig holds Vite configuration.
 type ViteConfig struct {
 	HotFile          string
@@ -38,9 +33,6 @@ type ViteConfig struct {
 	EmbedFS          fs.FS // Optional fs.FS (embed.FS or os.DirFS) for production builds
 	UseEmbedFS       bool  // Whether to use embed.FS for manifest loading
 
-	// Asset management configuration
-	Nonce             string          // Static CSP nonce
-	NonceGenerator    NonceGenerator  // Dynamic nonce generator (called once)
 	IntegrityKey      *string         // Manifest key for SRI hashes (nil = disabled)
 	EntryPoints       []string        // Entry points for asset generation
 	PreloadStrategy   PreloadStrategy // How to handle dependency loading
@@ -91,27 +83,6 @@ func WithHotReloadPort(port string) ViteOption {
 	}
 }
 
-// WithNonce sets a static CSP nonce.
-func WithNonce(nonce string) ViteOption {
-	return func(c *ViteConfig) {
-		c.Nonce = nonce
-	}
-}
-
-// WithAutoNonce generates a cryptographically secure nonce automatically.
-func WithAutoNonce() ViteOption {
-	return func(c *ViteConfig) {
-		c.Nonce = generateCryptoNonce()
-	}
-}
-
-// WithNonceGenerator sets a custom nonce generator function.
-func WithNonceGenerator(gen NonceGenerator) ViteOption {
-	return func(c *ViteConfig) {
-		c.NonceGenerator = gen
-	}
-}
-
 // WithIntegrity enables SubResource Integrity with the default manifest key "integrity".
 func WithIntegrity() ViteOption {
 	return func(c *ViteConfig) {
@@ -134,27 +105,21 @@ func WithEntryPoints(entries ...string) ViteOption {
 	}
 }
 
-// WithoutPreloading disables preloading. Browser handles module discovery naturally.
-// This is the default behavior.
+// WithoutPreloading disables preloading (default).
 func WithoutPreloading() ViteOption {
 	return withPreloadStrategy(PreloadNone, 0)
 }
 
-// WithAggressivePreload enables aggressive preloading of all dependencies.
-// All JavaScript imports are preloaded immediately using modulepreload.
+// WithAggressivePreload preloads all dependencies immediately.
 func WithAggressivePreload() ViteOption {
 	return withPreloadStrategy(PreloadAggressive, 0)
 }
 
 // WithWaterfallPreload enables batched prefetch with concurrency control.
-// Assets are loaded after page load in batches. concurrent controls how many
-// assets load in parallel (default: 3 if not specified or <= 0).
 func WithWaterfallPreload(concurrent int) ViteOption {
 	return withPreloadStrategy(PreloadWaterfall, concurrent)
 }
 
-// withPreloadStrategy sets the preload strategy and concurrency.
-// This is the internal implementation used by public helpers.
 func withPreloadStrategy(strategy PreloadStrategy, concurrent int) ViteOption {
 	return func(c *ViteConfig) {
 		c.PreloadStrategy = strategy
@@ -162,30 +127,22 @@ func withPreloadStrategy(strategy PreloadStrategy, concurrent int) ViteOption {
 	}
 }
 
-// generateCryptoNonce creates a cryptographically secure random nonce.
-func generateCryptoNonce() string {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return ""
-	}
-	return base64.StdEncoding.EncodeToString(b)
-}
-
-// NewVite creates a Vite instance with the given Inertia instance.
-// This uses the file system for hot reload detection and manifest loading.
-func NewVite(i *Inertia, opts ...ViteOption) (*ViteInstance, error) {
-	config := ViteConfig{
-		HotFile:          "public/hot",
-		BuildManifest:    "public/build/manifest.json",
-		FallbackManifest: "public/build/.vite/manifest.json",
-		BuildDir:         "/build/",
-		HotReloadPort:    "//localhost:5173",
-		UseEmbedFS:       false,
-
-		// Default configuration
+func defaultViteConfig() ViteConfig {
+	return ViteConfig{
+		HotFile:           "public/hot",
+		BuildManifest:     "public/build/manifest.json",
+		FallbackManifest:  "public/build/.vite/manifest.json",
+		BuildDir:          "/build/",
+		HotReloadPort:     "//localhost:5173",
 		PreloadStrategy:   PreloadNone,
 		PreloadConcurrent: 3,
 	}
+}
+
+// NewVite creates a Vite instance with file system for manifest loading.
+func NewVite(i *Inertia, opts ...ViteOption) (*ViteInstance, error) {
+	config := defaultViteConfig()
+	config.UseEmbedFS = false
 
 	for _, opt := range opts {
 		opt(&config)
@@ -203,22 +160,11 @@ func NewVite(i *Inertia, opts ...ViteOption) (*ViteInstance, error) {
 	return vi, nil
 }
 
-// NewViteFromFS creates a Vite instance using fs.FS (embed.FS or os.DirFS) for production builds.
-// It checks for hot reload file first (for development), otherwise uses the provided fs.FS.
+// NewViteFromFS creates a Vite instance using fs.FS for production builds.
 func NewViteFromFS(i *Inertia, embedFS fs.FS, opts ...ViteOption) (*ViteInstance, error) {
-	config := ViteConfig{
-		HotFile:          "public/hot",
-		BuildManifest:    "public/build/manifest.json",
-		FallbackManifest: "public/build/.vite/manifest.json",
-		BuildDir:         "/build/",
-		HotReloadPort:    "//localhost:5173",
-		EmbedFS:          embedFS,
-		UseEmbedFS:       true,
-
-		// Default configuration
-		PreloadStrategy:   PreloadNone,
-		PreloadConcurrent: 3,
-	}
+	config := defaultViteConfig()
+	config.EmbedFS = embedFS
+	config.UseEmbedFS = true
 
 	for _, opt := range opts {
 		opt(&config)
@@ -259,6 +205,10 @@ func (vi *ViteInstance) setup() error {
 
 	if err := vi.ShareTemplateFunc("viteAssets", vi.generateAllAssets); err != nil {
 		return fmt.Errorf("share viteAssets function: %w", err)
+	}
+
+	if err := vi.ShareTemplateFunc("viteAssetsWithNonce", vi.generateAllAssetsWithNonce); err != nil {
+		return fmt.Errorf("share viteAssetsWithNonce function: %w", err)
 	}
 
 	vi.ShareTemplateData("hmr", hotReload)
@@ -391,11 +341,18 @@ func (vi *ViteInstance) findManifestInEmbed() (string, error) {
 func (vi *ViteInstance) reactRefreshHelper(hotReload bool) func() template.HTML {
 	return func() template.HTML {
 		if !hotReload {
-			return template.HTML("") // No React Refresh in production
+			return template.HTML("")
 		}
 
-		viteClientURL, _ := vi.assetResolver(hotReload)("@vite/client")
-		reactRefreshURL, _ := vi.assetResolver(hotReload)("@react-refresh")
+		viteClientURL, err := vi.assetResolver(hotReload)("@vite/client")
+		if err != nil {
+			return template.HTML("")
+		}
+
+		reactRefreshURL, err := vi.assetResolver(hotReload)("@react-refresh")
+		if err != nil {
+			return template.HTML("")
+		}
 
 		html := fmt.Sprintf(`<script type="module" src="%s"></script>
 <script type="module">
@@ -413,10 +370,13 @@ func (vi *ViteInstance) reactRefreshHelper(hotReload bool) func() template.HTML 
 func (vi *ViteInstance) refreshHelper(hotReload bool) func() template.HTML {
 	return func() template.HTML {
 		if !hotReload {
-			return template.HTML("") // No refresh in production
+			return template.HTML("")
 		}
 
-		viteClientURL, _ := vi.assetResolver(hotReload)("@vite/client")
+		viteClientURL, err := vi.assetResolver(hotReload)("@vite/client")
+		if err != nil {
+			return template.HTML("")
+		}
 
 		html := fmt.Sprintf(`<script type="module" src="%s"></script>`, viteClientURL)
 
@@ -430,13 +390,12 @@ func (vi *ViteInstance) findManifest() (string, error) {
 	}
 
 	if _, err := os.Stat(vi.viteConfig.FallbackManifest); err == nil {
-		if err := os.Rename(vi.viteConfig.FallbackManifest, vi.viteConfig.BuildManifest); err != nil {
-			return "", fmt.Errorf("move manifest: %w", err)
-		}
-		return vi.viteConfig.BuildManifest, nil
+		return vi.viteConfig.FallbackManifest, nil
 	}
 
-	return "", fmt.Errorf("manifest not found")
+	return "", fmt.Errorf("manifest not found at %q or %q",
+		vi.viteConfig.BuildManifest,
+		vi.viteConfig.FallbackManifest)
 }
 
 // Asset represents a Vite manifest entry.

--- a/vite_assets.go
+++ b/vite_assets.go
@@ -1,22 +1,20 @@
-// Asset generation logic for Vite integration.
 package gonertia
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"strings"
 )
 
-// viteAssets tracks generated tags during asset processing.
 type viteAssets struct {
-	processedAssets map[string]bool // Track processed to avoid duplicates
-	preloadTags     []template.HTML // <link rel="modulepreload">
-	stylesheetTags  []template.HTML // <link rel="stylesheet">
-	scriptTags      []template.HTML // <script type="module">
-	prefetchAssets  []string        // Assets for waterfall prefetch
+	processedAssets map[string]bool
+	preloadTags     []template.HTML
+	stylesheetTags  []template.HTML
+	scriptTags      []template.HTML
+	prefetchAssets  []string
 }
 
-// htmlStrings converts template.HTML slice to string slice.
 func (va *viteAssets) htmlStrings(tags []template.HTML) []string {
 	result := make([]string, len(tags))
 	for i, tag := range tags {
@@ -25,23 +23,14 @@ func (va *viteAssets) htmlStrings(tags []template.HTML) []string {
 	return result
 }
 
-// resolveNonce gets the nonce to use for this ViteInstance.
-func (vi *ViteInstance) resolveNonce() string {
-	// 1. Use static nonce if set
-	if vi.viteConfig.Nonce != "" {
-		return vi.viteConfig.Nonce
-	}
-
-	// 2. Call generator if provided
-	if vi.viteConfig.NonceGenerator != nil {
-		return vi.viteConfig.NonceGenerator()
-	}
-
-	// 3. No nonce
-	return ""
+func (vi *ViteInstance) isJavaScript(asset Asset) bool {
+	return strings.HasSuffix(asset.File, ".js")
 }
 
-// processAsset recursively processes an asset and its dependencies.
+func (vi *ViteInstance) isStylesheet(asset Asset) bool {
+	return strings.HasSuffix(asset.File, ".css")
+}
+
 func (vi *ViteInstance) processAsset(
 	src string,
 	manifest map[string]Asset,
@@ -53,10 +42,9 @@ func (vi *ViteInstance) processAsset(
 		return nil
 	}
 
-	// Get asset from manifest
 	asset, ok := manifest[src]
 	if !ok {
-		return fmt.Errorf("asset %q not found in manifest", src)
+		return fmt.Errorf("asset %q not found in manifest (%d entries available)", src, len(manifest))
 	}
 
 	// Mark as processed
@@ -85,35 +73,28 @@ func (vi *ViteInstance) processAsset(
 		assets.processedAssets[cssPath] = true
 	}
 
-	// Handle based on preload strategy
 	switch vi.viteConfig.PreloadStrategy {
 	case PreloadAggressive:
-		// Add modulepreload for all JavaScript imports
-		if strings.HasSuffix(asset.File, ".js") {
+		if vi.isJavaScript(asset) {
 			tag := vi.generatePreloadTag(asset, nonce)
 			assets.preloadTags = append(assets.preloadTags, tag)
 		}
 
 	case PreloadWaterfall:
-		// Add to prefetch list (will be loaded after page load)
-		// Skip the entry itself (it's in scriptTags)
-		if !asset.IsEntry && strings.HasSuffix(asset.File, ".js") {
+		if !asset.IsEntry && vi.isJavaScript(asset) {
 			url := vi.viteConfig.BuildDir + asset.File
 			assets.prefetchAssets = append(assets.prefetchAssets, url)
 		}
 
 	case PreloadNone:
-		// Do nothing - browser handles discovery
 	}
 
-	// Add script tag ONLY for JavaScript entry points
-	if asset.IsEntry && strings.HasSuffix(asset.File, ".js") {
+	if asset.IsEntry && vi.isJavaScript(asset) {
 		tag := vi.generateScriptTag(asset, nonce)
 		assets.scriptTags = append(assets.scriptTags, tag)
 	}
 
-	// Add stylesheet tag for CSS entry points
-	if asset.IsEntry && strings.HasSuffix(asset.File, ".css") {
+	if asset.IsEntry && vi.isStylesheet(asset) {
 		tag := vi.generateStylesheetTag(asset, nonce)
 		assets.stylesheetTags = append(assets.stylesheetTags, tag)
 	}
@@ -121,7 +102,6 @@ func (vi *ViteInstance) processAsset(
 	return nil
 }
 
-// generatePreloadTag generates a modulepreload link tag.
 func (vi *ViteInstance) generatePreloadTag(asset Asset, nonce string) template.HTML {
 	url := vi.viteConfig.BuildDir + asset.File
 
@@ -143,7 +123,6 @@ func (vi *ViteInstance) generatePreloadTag(asset Asset, nonce string) template.H
 	return template.HTML(fmt.Sprintf(`<link %s>`, strings.Join(attrs, " ")))
 }
 
-// generateStylesheetTag generates a stylesheet link tag.
 func (vi *ViteInstance) generateStylesheetTag(asset Asset, nonce string) template.HTML {
 	url := vi.viteConfig.BuildDir + asset.File
 
@@ -164,7 +143,6 @@ func (vi *ViteInstance) generateStylesheetTag(asset Asset, nonce string) templat
 	return template.HTML(fmt.Sprintf(`<link %s>`, strings.Join(attrs, " ")))
 }
 
-// generateScriptTag generates a module script tag.
 func (vi *ViteInstance) generateScriptTag(asset Asset, nonce string) template.HTML {
 	url := vi.viteConfig.BuildDir + asset.File
 
@@ -185,9 +163,6 @@ func (vi *ViteInstance) generateScriptTag(asset Asset, nonce string) template.HT
 	return template.HTML(fmt.Sprintf(`<script %s></script>`, strings.Join(attrs, " ")))
 }
 
-// getIntegrity retrieves integrity hash from asset.
-// Returns the integrity hash if present in the manifest (e.g., from vite-plugin-manifest-sri).
-// The hash is used for SubResource Integrity (SRI) to verify asset integrity.
 func (vi *ViteInstance) getIntegrity(asset Asset) string {
 	return asset.Integrity
 }
@@ -198,13 +173,23 @@ func (vi *ViteInstance) getIntegrity(asset Asset) string {
 // It routes to hot reload or production mode based on environment.
 func (vi *ViteInstance) generateAllAssets(entries ...string) (template.HTML, error) {
 	if vi.isHotReload() {
-		return vi.generateHotAssets(entries...)
+		return vi.buildHotAssets("", entries...)
 	}
-	return vi.generateProductionAssets(entries...)
+	return vi.buildAssets("", entries...)
 }
 
-// generateHotAssets generates tags for development mode with HMR support.
-func (vi *ViteInstance) generateHotAssets(entries ...string) (template.HTML, error) {
+// generateAllAssetsWithNonce is the template function for CSP-enabled asset output.
+// It accepts a nonce as the first parameter followed by variadic entry points.
+// Usage: {{ viteAssetsWithNonce .csp_nonce "app.js" "admin.js" }}
+// The nonce is added to all script, style, and preload tags for Content Security Policy.
+func (vi *ViteInstance) generateAllAssetsWithNonce(nonce string, entries ...string) (template.HTML, error) {
+	if vi.isHotReload() {
+		return vi.buildHotAssets(nonce, entries...)
+	}
+	return vi.buildAssets(nonce, entries...)
+}
+
+func (vi *ViteInstance) buildHotAssets(nonce string, entries ...string) (template.HTML, error) {
 	// Use provided entries or fall back to config
 	if len(entries) == 0 {
 		entries = vi.viteConfig.EntryPoints
@@ -217,28 +202,29 @@ func (vi *ViteInstance) generateHotAssets(entries ...string) (template.HTML, err
 
 	hotURL := vi.readHotReloadURL()
 
-	// Pre-allocate: 1 for Vite client + entry points
 	tags := make([]string, 0, 1+len(entries))
 
-	// Add Vite HMR client
+	nonceAttr := ""
+	if nonce != "" {
+		nonceAttr = fmt.Sprintf(` nonce="%s"`, nonce)
+	}
+
 	tags = append(tags, fmt.Sprintf(
-		`<script type="module" src="%s/@vite/client"></script>`,
-		hotURL,
+		`<script type="module"%s src="%s/@vite/client"></script>`,
+		nonceAttr, hotURL,
 	))
 
-	// Add each entry point
 	for _, entry := range entries {
 		tags = append(tags, fmt.Sprintf(
-			`<script type="module" src="%s/%s"></script>`,
-			hotURL, entry,
+			`<script type="module"%s src="%s/%s"></script>`,
+			nonceAttr, hotURL, entry,
 		))
 	}
 
 	return template.HTML(strings.Join(tags, "\n")), nil
 }
 
-// generateProductionAssets generates optimized tags for production.
-func (vi *ViteInstance) generateProductionAssets(entries ...string) (template.HTML, error) {
+func (vi *ViteInstance) buildAssets(nonce string, entries ...string) (template.HTML, error) {
 	// Use provided entries or fall back to config
 	if len(entries) == 0 {
 		entries = vi.viteConfig.EntryPoints
@@ -260,9 +246,6 @@ func (vi *ViteInstance) generateProductionAssets(entries ...string) (template.HT
 		processedAssets: make(map[string]bool),
 		prefetchAssets:  []string{},
 	}
-
-	// Resolve nonce once for all tags
-	nonce := vi.resolveNonce()
 
 	// Process each entry and its dependencies
 	for _, entry := range entries {
@@ -292,7 +275,6 @@ func (vi *ViteInstance) generateProductionAssets(entries ...string) (template.HT
 	return template.HTML(strings.Join(allTags, "\n")), nil
 }
 
-// generateWaterfallScript generates an inline script for batched prefetching.
 func (vi *ViteInstance) generateWaterfallScript(prefetchAssets []string, nonce string) template.HTML {
 	if len(prefetchAssets) == 0 {
 		return ""
@@ -304,48 +286,46 @@ func (vi *ViteInstance) generateWaterfallScript(prefetchAssets []string, nonce s
 		concurrent = 3
 	}
 
-	// Build JavaScript assets array
-	var assetsJSON strings.Builder
-	assetsJSON.WriteString("[")
-	for i, url := range prefetchAssets {
-		if i > 0 {
-			assetsJSON.WriteString(",")
-		}
-		// Escape quotes in URL
-		escapedURL := strings.ReplaceAll(url, `"`, `\"`)
-		assetsJSON.WriteString(fmt.Sprintf(`{href:"%s",rel:"prefetch"}`, escapedURL))
+	type asset struct {
+		Href string `json:"href"`
+		Rel  string `json:"rel"`
 	}
-	assetsJSON.WriteString("]")
 
-	// Build nonce attribute
+	assets := make([]asset, len(prefetchAssets))
+	for i, url := range prefetchAssets {
+		assets[i] = asset{Href: url, Rel: "prefetch"}
+	}
+
+	assetsJSON, _ := json.Marshal(assets)
+
 	nonceAttr := ""
 	if nonce != "" {
 		nonceAttr = fmt.Sprintf(` nonce="%s"`, nonce)
 	}
 
-	// Generate the waterfall script (minified)
 	script := fmt.Sprintf(`<script%s>
-window.addEventListener('load',()=>setTimeout(()=>{
-const loadNext=(assets,count)=>{
-if(count>assets.length)count=assets.length
-const fragment=new DocumentFragment
-while(count>0){
-const cfg=assets.shift()
-const link=document.createElement('link')
-link.href=cfg.href
-link.rel=cfg.rel
-fragment.append(link)
-count--
-if(assets.length){
-link.onload=()=>loadNext(assets,1)
-link.onerror=()=>loadNext(assets,1)
-}
-}
-document.head.append(fragment)
-}
-loadNext(%s,%d)
-}))
-</script>`, nonceAttr, assetsJSON.String(), concurrent)
+window.addEventListener('load', () => {
+  const assets = %s;
+  const loadNext = (remaining, count) => {
+    if (count > remaining.length) count = remaining.length;
+    const fragment = new DocumentFragment();
+    while (count > 0) {
+      const cfg = remaining.shift();
+      const link = document.createElement('link');
+      link.href = cfg.href;
+      link.rel = cfg.rel;
+      fragment.append(link);
+      count--;
+      if (remaining.length) {
+        link.onload = () => loadNext(remaining, 1);
+        link.onerror = () => loadNext(remaining, 1);
+      }
+    }
+    document.head.append(fragment);
+  };
+  loadNext(assets, %d);
+});
+</script>`, nonceAttr, string(assetsJSON), concurrent)
 
 	return template.HTML(script)
 }

--- a/vite_assets.go
+++ b/vite_assets.go
@@ -1,0 +1,345 @@
+// Asset generation logic for Vite integration.
+package gonertia
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+// viteAssets tracks generated tags during asset processing.
+type viteAssets struct {
+	processedAssets map[string]bool // Track processed to avoid duplicates
+	preloadTags     []template.HTML // <link rel="modulepreload">
+	stylesheetTags  []template.HTML // <link rel="stylesheet">
+	scriptTags      []template.HTML // <script type="module">
+	prefetchAssets  []string        // Assets for waterfall prefetch
+}
+
+// htmlStrings converts template.HTML slice to string slice.
+func (va *viteAssets) htmlStrings(tags []template.HTML) []string {
+	result := make([]string, len(tags))
+	for i, tag := range tags {
+		result[i] = string(tag)
+	}
+	return result
+}
+
+// resolveNonce gets the nonce to use for this ViteInstance.
+func (vi *ViteInstance) resolveNonce() string {
+	// 1. Use static nonce if set
+	if vi.viteConfig.Nonce != "" {
+		return vi.viteConfig.Nonce
+	}
+
+	// 2. Call generator if provided
+	if vi.viteConfig.NonceGenerator != nil {
+		return vi.viteConfig.NonceGenerator()
+	}
+
+	// 3. No nonce
+	return ""
+}
+
+// processAsset recursively processes an asset and its dependencies.
+func (vi *ViteInstance) processAsset(
+	src string,
+	manifest map[string]Asset,
+	assets *viteAssets,
+	nonce string,
+) error {
+	// Skip if already processed
+	if assets.processedAssets[src] {
+		return nil
+	}
+
+	// Get asset from manifest
+	asset, ok := manifest[src]
+	if !ok {
+		return fmt.Errorf("asset %q not found in manifest", src)
+	}
+
+	// Mark as processed
+	assets.processedAssets[src] = true
+
+	// Process static dependencies first (depth-first for proper load order)
+	for _, imp := range asset.Imports {
+		if err := vi.processAsset(imp, manifest, assets, nonce); err != nil {
+			return err
+		}
+	}
+
+	// Process CSS files
+	for _, cssPath := range asset.Css {
+		if assets.processedAssets[cssPath] {
+			continue
+		}
+
+		cssAsset, ok := manifest[cssPath]
+		if !ok {
+			continue
+		}
+
+		tag := vi.generateStylesheetTag(cssAsset, nonce)
+		assets.stylesheetTags = append(assets.stylesheetTags, tag)
+		assets.processedAssets[cssPath] = true
+	}
+
+	// Handle based on preload strategy
+	switch vi.viteConfig.PreloadStrategy {
+	case PreloadAggressive:
+		// Add modulepreload for all JavaScript imports
+		if strings.HasSuffix(asset.File, ".js") {
+			tag := vi.generatePreloadTag(asset, nonce)
+			assets.preloadTags = append(assets.preloadTags, tag)
+		}
+
+	case PreloadWaterfall:
+		// Add to prefetch list (will be loaded after page load)
+		// Skip the entry itself (it's in scriptTags)
+		if !asset.IsEntry && strings.HasSuffix(asset.File, ".js") {
+			url := vi.viteConfig.BuildDir + asset.File
+			assets.prefetchAssets = append(assets.prefetchAssets, url)
+		}
+
+	case PreloadNone:
+		// Do nothing - browser handles discovery
+	}
+
+	// Add script tag ONLY for entry points
+	if asset.IsEntry {
+		tag := vi.generateScriptTag(asset, nonce)
+		assets.scriptTags = append(assets.scriptTags, tag)
+	}
+
+	return nil
+}
+
+// generatePreloadTag generates a modulepreload link tag.
+func (vi *ViteInstance) generatePreloadTag(asset Asset, nonce string) template.HTML {
+	url := vi.viteConfig.BuildDir + asset.File
+
+	var attrs []string
+	attrs = append(attrs, `rel="modulepreload"`)
+	attrs = append(attrs, fmt.Sprintf(`href="%s"`, url))
+	attrs = append(attrs, `crossorigin`) // Required for modules
+
+	// Add integrity if available
+	if integrity := vi.getIntegrity(asset); integrity != "" {
+		attrs = append(attrs, fmt.Sprintf(`integrity="%s"`, integrity))
+	}
+
+	// Add nonce if present
+	if nonce != "" {
+		attrs = append(attrs, fmt.Sprintf(`nonce="%s"`, nonce))
+	}
+
+	return template.HTML(fmt.Sprintf(`<link %s>`, strings.Join(attrs, " ")))
+}
+
+// generateStylesheetTag generates a stylesheet link tag.
+func (vi *ViteInstance) generateStylesheetTag(asset Asset, nonce string) template.HTML {
+	url := vi.viteConfig.BuildDir + asset.File
+
+	var attrs []string
+	attrs = append(attrs, `rel="stylesheet"`)
+	attrs = append(attrs, fmt.Sprintf(`href="%s"`, url))
+
+	// Add integrity if available
+	if integrity := vi.getIntegrity(asset); integrity != "" {
+		attrs = append(attrs, fmt.Sprintf(`integrity="%s"`, integrity))
+	}
+
+	// Add nonce if present
+	if nonce != "" {
+		attrs = append(attrs, fmt.Sprintf(`nonce="%s"`, nonce))
+	}
+
+	return template.HTML(fmt.Sprintf(`<link %s>`, strings.Join(attrs, " ")))
+}
+
+// generateScriptTag generates a module script tag.
+func (vi *ViteInstance) generateScriptTag(asset Asset, nonce string) template.HTML {
+	url := vi.viteConfig.BuildDir + asset.File
+
+	var attrs []string
+	attrs = append(attrs, `type="module"`)
+	attrs = append(attrs, fmt.Sprintf(`src="%s"`, url))
+
+	// Add integrity if available
+	if integrity := vi.getIntegrity(asset); integrity != "" {
+		attrs = append(attrs, fmt.Sprintf(`integrity="%s"`, integrity))
+	}
+
+	// Add nonce if present
+	if nonce != "" {
+		attrs = append(attrs, fmt.Sprintf(`nonce="%s"`, nonce))
+	}
+
+	return template.HTML(fmt.Sprintf(`<script %s></script>`, strings.Join(attrs, " ")))
+}
+
+// getIntegrity retrieves integrity hash from asset.
+// Returns the integrity hash if present in the manifest (e.g., from vite-plugin-manifest-sri).
+// The hash is used for SubResource Integrity (SRI) to verify asset integrity.
+func (vi *ViteInstance) getIntegrity(asset Asset) string {
+	return asset.Integrity
+}
+
+// generateAllAssets is the main template function that outputs all Vite assets.
+// It accepts variadic entry points: {{ viteAssets "app.js" "admin.js" }}
+// If no args provided, uses vi.viteConfig.EntryPoints from config.
+// It routes to hot reload or production mode based on environment.
+func (vi *ViteInstance) generateAllAssets(entries ...string) (template.HTML, error) {
+	if vi.isHotReload() {
+		return vi.generateHotAssets(entries...)
+	}
+	return vi.generateProductionAssets(entries...)
+}
+
+// generateHotAssets generates tags for development mode with HMR support.
+func (vi *ViteInstance) generateHotAssets(entries ...string) (template.HTML, error) {
+	// Use provided entries or fall back to config
+	if len(entries) == 0 {
+		entries = vi.viteConfig.EntryPoints
+	}
+
+	// Error if no entries configured
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no entry points configured: use WithEntryPoints() or provide template args")
+	}
+
+	hotURL := vi.readHotReloadURL()
+
+	// Pre-allocate: 1 for Vite client + entry points
+	tags := make([]string, 0, 1+len(entries))
+
+	// Add Vite HMR client
+	tags = append(tags, fmt.Sprintf(
+		`<script type="module" src="%s/@vite/client"></script>`,
+		hotURL,
+	))
+
+	// Add each entry point
+	for _, entry := range entries {
+		tags = append(tags, fmt.Sprintf(
+			`<script type="module" src="%s/%s"></script>`,
+			hotURL, entry,
+		))
+	}
+
+	return template.HTML(strings.Join(tags, "\n")), nil
+}
+
+// generateProductionAssets generates optimized tags for production.
+func (vi *ViteInstance) generateProductionAssets(entries ...string) (template.HTML, error) {
+	// Use provided entries or fall back to config
+	if len(entries) == 0 {
+		entries = vi.viteConfig.EntryPoints
+	}
+
+	// Error if no entries configured
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no entry points configured: use WithEntryPoints() or provide template args")
+	}
+
+	// Load manifest
+	manifest, err := vi.loadManifest()
+	if err != nil {
+		return "", fmt.Errorf("load manifest: %w", err)
+	}
+
+	// Initialize asset tracker
+	assets := &viteAssets{
+		processedAssets: make(map[string]bool),
+		prefetchAssets:  []string{},
+	}
+
+	// Resolve nonce once for all tags
+	nonce := vi.resolveNonce()
+
+	// Process each entry and its dependencies
+	for _, entry := range entries {
+		if err := vi.processAsset(entry, manifest, assets, nonce); err != nil {
+			return "", fmt.Errorf("process asset %q: %w", entry, err)
+		}
+	}
+
+	// Build final output
+	var allTags []string
+
+	// 1. Modulepreload tags (for aggressive strategy)
+	allTags = append(allTags, assets.htmlStrings(assets.preloadTags)...)
+
+	// 2. Stylesheet tags
+	allTags = append(allTags, assets.htmlStrings(assets.stylesheetTags)...)
+
+	// 3. Script tags (entry points)
+	allTags = append(allTags, assets.htmlStrings(assets.scriptTags)...)
+
+	// 4. Waterfall prefetch script (if strategy enabled)
+	if vi.viteConfig.PreloadStrategy == PreloadWaterfall && len(assets.prefetchAssets) > 0 {
+		script := vi.generateWaterfallScript(assets.prefetchAssets, nonce)
+		allTags = append(allTags, string(script))
+	}
+
+	return template.HTML(strings.Join(allTags, "\n")), nil
+}
+
+// generateWaterfallScript generates an inline script for batched prefetching.
+func (vi *ViteInstance) generateWaterfallScript(prefetchAssets []string, nonce string) template.HTML {
+	if len(prefetchAssets) == 0 {
+		return ""
+	}
+
+	// Default concurrent to 3 if not set or invalid
+	concurrent := vi.viteConfig.PreloadConcurrent
+	if concurrent <= 0 {
+		concurrent = 3
+	}
+
+	// Build JavaScript assets array
+	var assetsJSON strings.Builder
+	assetsJSON.WriteString("[")
+	for i, url := range prefetchAssets {
+		if i > 0 {
+			assetsJSON.WriteString(",")
+		}
+		// Escape quotes in URL
+		escapedURL := strings.ReplaceAll(url, `"`, `\"`)
+		assetsJSON.WriteString(fmt.Sprintf(`{href:"%s",rel:"prefetch"}`, escapedURL))
+	}
+	assetsJSON.WriteString("]")
+
+	// Build nonce attribute
+	nonceAttr := ""
+	if nonce != "" {
+		nonceAttr = fmt.Sprintf(` nonce="%s"`, nonce)
+	}
+
+	// Generate the waterfall script (minified)
+	script := fmt.Sprintf(`<script%s>
+window.addEventListener('load',()=>setTimeout(()=>{
+const loadNext=(assets,count)=>{
+if(count>assets.length)count=assets.length
+const fragment=new DocumentFragment
+while(count>0){
+const cfg=assets.shift()
+const link=document.createElement('link')
+link.href=cfg.href
+link.rel=cfg.rel
+fragment.append(link)
+count--
+if(assets.length){
+link.onload=()=>loadNext(assets,1)
+link.onerror=()=>loadNext(assets,1)
+}
+}
+document.head.append(fragment)
+}
+loadNext(%s,%d)
+}))
+</script>`, nonceAttr, assetsJSON.String(), concurrent)
+
+	return template.HTML(script)
+}

--- a/vite_assets.go
+++ b/vite_assets.go
@@ -106,10 +106,16 @@ func (vi *ViteInstance) processAsset(
 		// Do nothing - browser handles discovery
 	}
 
-	// Add script tag ONLY for entry points
-	if asset.IsEntry {
+	// Add script tag ONLY for JavaScript entry points
+	if asset.IsEntry && strings.HasSuffix(asset.File, ".js") {
 		tag := vi.generateScriptTag(asset, nonce)
 		assets.scriptTags = append(assets.scriptTags, tag)
+	}
+
+	// Add stylesheet tag for CSS entry points
+	if asset.IsEntry && strings.HasSuffix(asset.File, ".css") {
+		tag := vi.generateStylesheetTag(asset, nonce)
+		assets.stylesheetTags = append(assets.stylesheetTags, tag)
 	}
 
 	return nil

--- a/vite_assets_test.go
+++ b/vite_assets_test.go
@@ -30,7 +30,7 @@ func TestEntryPointHandling(t *testing.T) {
 		}
 
 		// Template args should override config
-		html, err := vi.generateHotAssets("template-arg.js")
+		html, err := vi.buildHotAssets("", "template-arg.js")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -63,7 +63,7 @@ func TestEntryPointHandling(t *testing.T) {
 			},
 		}
 
-		html, err := vi.generateHotAssets()
+		html, err := vi.buildHotAssets("")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestEntryPointHandling(t *testing.T) {
 			},
 		}
 
-		_, err := vi.generateHotAssets()
+		_, err := vi.buildHotAssets("")
 		if err == nil {
 			t.Error("expected error when no entries configured")
 		}
@@ -118,7 +118,7 @@ func TestEntryPointHandling(t *testing.T) {
 			},
 		}
 
-		html, err := vi.generateHotAssets("app.js", "admin.js")
+		html, err := vi.buildHotAssets("", "app.js", "admin.js")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -130,85 +130,6 @@ func TestEntryPointHandling(t *testing.T) {
 
 		if !strings.Contains(htmlStr, "admin.js") {
 			t.Error("should include second entry")
-		}
-	})
-}
-
-func TestResolveNonce(t *testing.T) {
-	t.Parallel()
-
-	t.Run("static nonce", func(t *testing.T) {
-		t.Parallel()
-
-		vi := &ViteInstance{
-			viteConfig: ViteConfig{
-				Nonce: "static-nonce-123",
-			},
-		}
-
-		nonce := vi.resolveNonce()
-		if nonce != "static-nonce-123" {
-			t.Errorf("expected static-nonce-123, got %s", nonce)
-		}
-	})
-
-	t.Run("generated nonce", func(t *testing.T) {
-		t.Parallel()
-
-		called := false
-		vi := &ViteInstance{
-			viteConfig: ViteConfig{
-				NonceGenerator: func() string {
-					called = true
-					return "generated-nonce"
-				},
-			},
-		}
-
-		nonce := vi.resolveNonce()
-		if nonce != "generated-nonce" {
-			t.Errorf("expected generated-nonce, got %s", nonce)
-		}
-
-		if !called {
-			t.Error("nonce generator was not called")
-		}
-	})
-
-	t.Run("no nonce", func(t *testing.T) {
-		t.Parallel()
-
-		vi := &ViteInstance{
-			viteConfig: ViteConfig{},
-		}
-
-		nonce := vi.resolveNonce()
-		if nonce != "" {
-			t.Errorf("expected empty string, got %s", nonce)
-		}
-	})
-
-	t.Run("static nonce takes precedence", func(t *testing.T) {
-		t.Parallel()
-
-		generatorCalled := false
-		vi := &ViteInstance{
-			viteConfig: ViteConfig{
-				Nonce: "static",
-				NonceGenerator: func() string {
-					generatorCalled = true
-					return "generated"
-				},
-			},
-		}
-
-		nonce := vi.resolveNonce()
-		if nonce != "static" {
-			t.Errorf("expected static, got %s", nonce)
-		}
-
-		if generatorCalled {
-			t.Error("generator should not be called when static nonce is set")
 		}
 	})
 }
@@ -524,7 +445,7 @@ func TestGenerateHotAssets(t *testing.T) {
 			},
 		}
 
-		html, err := vi.generateHotAssets()
+		html, err := vi.buildHotAssets("")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -592,7 +513,7 @@ func TestGenerateWaterfallScript(t *testing.T) {
 		}
 
 		// Should contain concurrent value
-		if !strings.Contains(scriptStr, ",3)") {
+		if !strings.Contains(scriptStr, "loadNext(assets, 3)") {
 			t.Error("should contain concurrent value")
 		}
 	})
@@ -995,7 +916,7 @@ func TestGenerateProductionAssets(t *testing.T) {
 			},
 		}
 
-		html, err := vi.generateProductionAssets()
+		html, err := vi.buildAssets("")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1025,95 +946,15 @@ func TestGenerateProductionAssets(t *testing.T) {
 			},
 		}
 
-		_, err := vi.generateProductionAssets()
+		_, err := vi.buildAssets("")
 		if err == nil {
 			t.Error("should return error when manifest not found")
-		}
-	})
-
-	t.Run("with nonce", func(t *testing.T) {
-		t.Parallel()
-
-		manifestPath := t.TempDir() + "/manifest.json"
-		manifest := map[string]Asset{
-			"app.js": {
-				File:    "assets/app-abc.js",
-				IsEntry: true,
-			},
-		}
-		data, _ := json.Marshal(manifest)
-		if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		i := &Inertia{}
-		vi := &ViteInstance{
-			Inertia: i,
-			viteConfig: ViteConfig{
-				BuildManifest: manifestPath,
-				BuildDir:      "/build/",
-				EntryPoints:   []string{"app.js"},
-				Nonce:         "test-nonce-123",
-			},
-		}
-
-		html, err := vi.generateProductionAssets()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		htmlStr := string(html)
-		if !strings.Contains(htmlStr, `nonce="test-nonce-123"`) {
-			t.Error("should include nonce in tags")
 		}
 	})
 }
 
 func TestViteOptionFunctions(t *testing.T) {
 	t.Parallel()
-
-	t.Run("WithNonce", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := &ViteConfig{}
-		WithNonce("test-nonce")(cfg)
-
-		if cfg.Nonce != "test-nonce" {
-			t.Errorf("expected test-nonce, got %s", cfg.Nonce)
-		}
-	})
-
-	t.Run("WithAutoNonce", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := &ViteConfig{}
-		WithAutoNonce()(cfg)
-
-		if cfg.Nonce == "" {
-			t.Error("Nonce should be auto-generated")
-		}
-
-		if len(cfg.Nonce) == 0 {
-			t.Error("generated nonce should not be empty")
-		}
-	})
-
-	t.Run("WithNonceGenerator", func(t *testing.T) {
-		t.Parallel()
-
-		customGen := func() string { return "custom-nonce" }
-		cfg := &ViteConfig{}
-		WithNonceGenerator(customGen)(cfg)
-
-		if cfg.NonceGenerator == nil {
-			t.Error("NonceGenerator should be set")
-		}
-
-		nonce := cfg.NonceGenerator()
-		if nonce != "custom-nonce" {
-			t.Errorf("expected custom-nonce, got %s", nonce)
-		}
-	})
 
 	t.Run("WithIntegrity", func(t *testing.T) {
 		t.Parallel()

--- a/vite_assets_test.go
+++ b/vite_assets_test.go
@@ -1,0 +1,1199 @@
+package gonertia
+
+import (
+	"encoding/json"
+	"html/template"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEntryPointHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("template args take precedence", func(t *testing.T) {
+		t.Parallel()
+
+		hotFile := t.TempDir() + "/hot"
+		if err := os.WriteFile(hotFile, []byte("http://localhost:5173"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       hotFile,
+				EntryPoints:   []string{"config-entry.js"}, // Should be ignored
+				HotReloadPort: "http://localhost:5173",
+			},
+		}
+
+		// Template args should override config
+		html, err := vi.generateHotAssets("template-arg.js")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+		if !strings.Contains(htmlStr, "template-arg.js") {
+			t.Error("should use template arg entry point")
+		}
+
+		if strings.Contains(htmlStr, "config-entry.js") {
+			t.Error("should not use config entry when template arg provided")
+		}
+	})
+
+	t.Run("config entries used when no template args", func(t *testing.T) {
+		t.Parallel()
+
+		hotFile := t.TempDir() + "/hot"
+		if err := os.WriteFile(hotFile, []byte("http://localhost:5173"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       hotFile,
+				EntryPoints:   []string{"app.js"},
+				HotReloadPort: "http://localhost:5173",
+			},
+		}
+
+		html, err := vi.generateHotAssets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+		if !strings.Contains(htmlStr, "app.js") {
+			t.Error("should use config entry point")
+		}
+	})
+
+	t.Run("error when no entries configured", func(t *testing.T) {
+		t.Parallel()
+
+		hotFile := t.TempDir() + "/hot"
+		if err := os.WriteFile(hotFile, []byte("http://localhost:5173"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       hotFile,
+				HotReloadPort: "http://localhost:5173",
+			},
+		}
+
+		_, err := vi.generateHotAssets()
+		if err == nil {
+			t.Error("expected error when no entries configured")
+		}
+
+		if !strings.Contains(err.Error(), "no entry points configured") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("multiple template args", func(t *testing.T) {
+		t.Parallel()
+
+		hotFile := t.TempDir() + "/hot"
+		if err := os.WriteFile(hotFile, []byte("http://localhost:5173"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       hotFile,
+				HotReloadPort: "http://localhost:5173",
+			},
+		}
+
+		html, err := vi.generateHotAssets("app.js", "admin.js")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+		if !strings.Contains(htmlStr, "app.js") {
+			t.Error("should include first entry")
+		}
+
+		if !strings.Contains(htmlStr, "admin.js") {
+			t.Error("should include second entry")
+		}
+	})
+}
+
+func TestResolveNonce(t *testing.T) {
+	t.Parallel()
+
+	t.Run("static nonce", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				Nonce: "static-nonce-123",
+			},
+		}
+
+		nonce := vi.resolveNonce()
+		if nonce != "static-nonce-123" {
+			t.Errorf("expected static-nonce-123, got %s", nonce)
+		}
+	})
+
+	t.Run("generated nonce", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				NonceGenerator: func() string {
+					called = true
+					return "generated-nonce"
+				},
+			},
+		}
+
+		nonce := vi.resolveNonce()
+		if nonce != "generated-nonce" {
+			t.Errorf("expected generated-nonce, got %s", nonce)
+		}
+
+		if !called {
+			t.Error("nonce generator was not called")
+		}
+	})
+
+	t.Run("no nonce", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{},
+		}
+
+		nonce := vi.resolveNonce()
+		if nonce != "" {
+			t.Errorf("expected empty string, got %s", nonce)
+		}
+	})
+
+	t.Run("static nonce takes precedence", func(t *testing.T) {
+		t.Parallel()
+
+		generatorCalled := false
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				Nonce: "static",
+				NonceGenerator: func() string {
+					generatorCalled = true
+					return "generated"
+				},
+			},
+		}
+
+		nonce := vi.resolveNonce()
+		if nonce != "static" {
+			t.Errorf("expected static, got %s", nonce)
+		}
+
+		if generatorCalled {
+			t.Error("generator should not be called when static nonce is set")
+		}
+	})
+}
+
+func TestGeneratePreloadTag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic preload tag", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File: "assets/app-abc123.js",
+		}
+
+		tag := vi.generatePreloadTag(asset, "")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `rel="modulepreload"`) {
+			t.Error("tag should contain rel=modulepreload")
+		}
+
+		if !strings.Contains(tagStr, `href="/build/assets/app-abc123.js"`) {
+			t.Error("tag should contain correct href")
+		}
+
+		if !strings.Contains(tagStr, `crossorigin`) {
+			t.Error("tag should contain crossorigin")
+		}
+	})
+
+	t.Run("preload tag with nonce", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File: "assets/app-abc123.js",
+		}
+
+		tag := vi.generatePreloadTag(asset, "test-nonce")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `nonce="test-nonce"`) {
+			t.Errorf("tag should contain nonce, got: %s", tagStr)
+		}
+	})
+}
+
+func TestGenerateStylesheetTag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic stylesheet tag", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File: "assets/app-abc123.css",
+		}
+
+		tag := vi.generateStylesheetTag(asset, "")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `rel="stylesheet"`) {
+			t.Error("tag should contain rel=stylesheet")
+		}
+
+		if !strings.Contains(tagStr, `href="/build/assets/app-abc123.css"`) {
+			t.Error("tag should contain correct href")
+		}
+	})
+
+	t.Run("stylesheet tag with nonce", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File: "assets/app-abc123.css",
+		}
+
+		tag := vi.generateStylesheetTag(asset, "test-nonce")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `nonce="test-nonce"`) {
+			t.Errorf("tag should contain nonce, got: %s", tagStr)
+		}
+	})
+}
+
+func TestGenerateScriptTag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic script tag", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File: "assets/app-abc123.js",
+		}
+
+		tag := vi.generateScriptTag(asset, "")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `type="module"`) {
+			t.Error("tag should contain type=module")
+		}
+
+		if !strings.Contains(tagStr, `src="/build/assets/app-abc123.js"`) {
+			t.Error("tag should contain correct src")
+		}
+
+		if !strings.HasPrefix(tagStr, "<script") || !strings.HasSuffix(tagStr, "</script>") {
+			t.Error("tag should be properly formatted script tag")
+		}
+	})
+
+	t.Run("script tag with nonce", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File: "assets/app-abc123.js",
+		}
+
+		tag := vi.generateScriptTag(asset, "test-nonce")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `nonce="test-nonce"`) {
+			t.Errorf("tag should contain nonce, got: %s", tagStr)
+		}
+	})
+}
+
+func TestGetIntegrity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns integrity hash when present", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{}
+		asset := Asset{
+			File:      "assets/app-abc123.js",
+			Integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC",
+		}
+
+		integrity := vi.getIntegrity(asset)
+		expected := "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"
+
+		if integrity != expected {
+			t.Errorf("expected %s, got %s", expected, integrity)
+		}
+	})
+
+	t.Run("returns empty string when no integrity", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{}
+		asset := Asset{
+			File: "assets/app-abc123.js",
+		}
+
+		integrity := vi.getIntegrity(asset)
+		if integrity != "" {
+			t.Errorf("expected empty string, got %s", integrity)
+		}
+	})
+}
+
+func TestSRIInTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preload tag includes integrity attribute", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File:      "assets/app-abc123.js",
+			Integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC",
+		}
+
+		tag := vi.generatePreloadTag(asset, "")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"`) {
+			t.Errorf("tag should contain integrity attribute, got: %s", tagStr)
+		}
+	})
+
+	t.Run("stylesheet tag includes integrity attribute", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File:      "assets/app-abc123.css",
+			Integrity: "sha384-xyzABC123",
+		}
+
+		tag := vi.generateStylesheetTag(asset, "")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `integrity="sha384-xyzABC123"`) {
+			t.Errorf("tag should contain integrity attribute, got: %s", tagStr)
+		}
+	})
+
+	t.Run("script tag includes integrity attribute", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File:      "assets/app-abc123.js",
+			Integrity: "sha384-xyzABC123",
+		}
+
+		tag := vi.generateScriptTag(asset, "")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `integrity="sha384-xyzABC123"`) {
+			t.Errorf("tag should contain integrity attribute, got: %s", tagStr)
+		}
+	})
+
+	t.Run("tags work with both nonce and integrity", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir: "/build/",
+			},
+		}
+
+		asset := Asset{
+			File:      "assets/app-abc123.js",
+			Integrity: "sha384-xyzABC123",
+		}
+
+		tag := vi.generateScriptTag(asset, "test-nonce")
+		tagStr := string(tag)
+
+		if !strings.Contains(tagStr, `integrity="sha384-xyzABC123"`) {
+			t.Error("tag should contain integrity attribute")
+		}
+
+		if !strings.Contains(tagStr, `nonce="test-nonce"`) {
+			t.Error("tag should contain nonce attribute")
+		}
+	})
+}
+
+func TestGenerateHotAssets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates hot reload tags", func(t *testing.T) {
+		t.Parallel()
+
+		// Create temp hot file
+		hotFile := t.TempDir() + "/hot"
+		if err := os.WriteFile(hotFile, []byte("//localhost:5173"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       hotFile,
+				EntryPoints:   []string{"resources/js/app.tsx"},
+				HotReloadPort: "//localhost:5173",
+			},
+		}
+
+		html, err := vi.generateHotAssets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+
+		// Should contain Vite client
+		if !strings.Contains(htmlStr, "/@vite/client") {
+			t.Error("should contain Vite client script")
+		}
+
+		// Should contain entry point
+		if !strings.Contains(htmlStr, "resources/js/app.tsx") {
+			t.Error("should contain entry point script")
+		}
+
+		// Should be script tags
+		if !strings.Contains(htmlStr, `<script type="module"`) {
+			t.Error("should contain script tags")
+		}
+	})
+}
+
+func TestGenerateWaterfallScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates waterfall script", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				PreloadConcurrent: 3,
+			},
+		}
+
+		assets := []string{
+			"/build/assets/chunk1.js",
+			"/build/assets/chunk2.js",
+			"/build/assets/chunk3.js",
+		}
+
+		script := vi.generateWaterfallScript(assets, "")
+		scriptStr := string(script)
+
+		// Should be a script tag
+		if !strings.HasPrefix(scriptStr, "<script") || !strings.HasSuffix(scriptStr, "</script>") {
+			t.Error("should be a script tag")
+		}
+
+		// Should contain load event listener
+		if !strings.Contains(scriptStr, "window.addEventListener('load'") {
+			t.Error("should contain load event listener")
+		}
+
+		// Should contain loadNext function
+		if !strings.Contains(scriptStr, "loadNext") {
+			t.Error("should contain loadNext function")
+		}
+
+		// Should contain all assets
+		for _, asset := range assets {
+			if !strings.Contains(scriptStr, asset) {
+				t.Errorf("should contain asset: %s", asset)
+			}
+		}
+
+		// Should contain concurrent value
+		if !strings.Contains(scriptStr, ",3)") {
+			t.Error("should contain concurrent value")
+		}
+	})
+
+	t.Run("includes nonce in script tag", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				PreloadConcurrent: 2,
+			},
+		}
+
+		assets := []string{"/build/assets/chunk1.js"}
+
+		script := vi.generateWaterfallScript(assets, "test-nonce-456")
+		scriptStr := string(script)
+
+		if !strings.Contains(scriptStr, `nonce="test-nonce-456"`) {
+			t.Error("should contain nonce attribute")
+		}
+	})
+
+	t.Run("returns empty for no assets", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{},
+		}
+
+		script := vi.generateWaterfallScript([]string{}, "")
+		if script != "" {
+			t.Error("should return empty for no assets")
+		}
+	})
+
+	t.Run("escapes quotes in URLs", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				PreloadConcurrent: 1,
+			},
+		}
+
+		assets := []string{`/build/assets/"quoted".js`}
+
+		script := vi.generateWaterfallScript(assets, "")
+		scriptStr := string(script)
+
+		// Should escape the quotes
+		if !strings.Contains(scriptStr, `\"quoted\"`) {
+			t.Error("should escape quotes in URLs")
+		}
+	})
+}
+
+func TestProcessAsset(t *testing.T) {
+	t.Parallel()
+
+	t.Run("processes entry asset with PreloadNone", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir:        "/build/",
+				PreloadStrategy: PreloadNone,
+			},
+		}
+
+		manifest := map[string]Asset{
+			"resources/js/app.tsx": {
+				File:    "assets/app-abc.js",
+				IsEntry: true,
+			},
+		}
+
+		assets := &viteAssets{
+			processedAssets: make(map[string]bool),
+		}
+
+		err := vi.processAsset("resources/js/app.tsx", manifest, assets, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should have script tag for entry
+		if len(assets.scriptTags) != 1 {
+			t.Errorf("expected 1 script tag, got %d", len(assets.scriptTags))
+		}
+
+		// Should have no preload tags (PreloadNone)
+		if len(assets.preloadTags) != 0 {
+			t.Errorf("expected 0 preload tags, got %d", len(assets.preloadTags))
+		}
+	})
+
+	t.Run("processes entry asset with PreloadAggressive", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir:        "/build/",
+				PreloadStrategy: PreloadAggressive,
+			},
+		}
+
+		manifest := map[string]Asset{
+			"resources/js/app.tsx": {
+				File:    "assets/app-abc.js",
+				IsEntry: true,
+				Imports: []string{"resources/js/helper.ts"},
+			},
+			"resources/js/helper.ts": {
+				File: "assets/helper-def.js",
+			},
+		}
+
+		assets := &viteAssets{
+			processedAssets: make(map[string]bool),
+		}
+
+		err := vi.processAsset("resources/js/app.tsx", manifest, assets, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should have preload tags for both entry and import
+		if len(assets.preloadTags) != 2 {
+			t.Errorf("expected 2 preload tags, got %d", len(assets.preloadTags))
+		}
+
+		// Should have script tag only for entry
+		if len(assets.scriptTags) != 1 {
+			t.Errorf("expected 1 script tag, got %d", len(assets.scriptTags))
+		}
+	})
+
+	t.Run("processes CSS files", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir:        "/build/",
+				PreloadStrategy: PreloadNone,
+			},
+		}
+
+		manifest := map[string]Asset{
+			"resources/js/app.tsx": {
+				File:    "assets/app-abc.js",
+				IsEntry: true,
+				Css:     []string{"resources/css/app.css"},
+			},
+			"resources/css/app.css": {
+				File: "assets/app-xyz.css",
+			},
+		}
+
+		assets := &viteAssets{
+			processedAssets: make(map[string]bool),
+		}
+
+		err := vi.processAsset("resources/js/app.tsx", manifest, assets, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should have stylesheet tag
+		if len(assets.stylesheetTags) != 1 {
+			t.Errorf("expected 1 stylesheet tag, got %d", len(assets.stylesheetTags))
+		}
+	})
+
+	t.Run("prevents duplicate processing", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{
+				BuildDir:        "/build/",
+				PreloadStrategy: PreloadAggressive,
+			},
+		}
+
+		manifest := map[string]Asset{
+			"resources/js/app.tsx": {
+				File:    "assets/app-abc.js",
+				IsEntry: true,
+				Imports: []string{"resources/js/shared.ts"},
+			},
+			"resources/js/admin.tsx": {
+				File:    "assets/admin-def.js",
+				IsEntry: true,
+				Imports: []string{"resources/js/shared.ts"},
+			},
+			"resources/js/shared.ts": {
+				File: "assets/shared-ghi.js",
+			},
+		}
+
+		assets := &viteAssets{
+			processedAssets: make(map[string]bool),
+		}
+
+		// Process both entries
+		_ = vi.processAsset("resources/js/app.tsx", manifest, assets, "")
+		_ = vi.processAsset("resources/js/admin.tsx", manifest, assets, "")
+
+		// Shared module should only be preloaded once
+		sharedCount := 0
+		for _, tag := range assets.preloadTags {
+			if strings.Contains(string(tag), "shared-ghi.js") {
+				sharedCount++
+			}
+		}
+
+		if sharedCount != 1 {
+			t.Errorf("expected shared module to be preloaded once, got %d times", sharedCount)
+		}
+	})
+
+	t.Run("error for missing asset", func(t *testing.T) {
+		t.Parallel()
+
+		vi := &ViteInstance{
+			viteConfig: ViteConfig{},
+		}
+
+		manifest := map[string]Asset{}
+
+		assets := &viteAssets{
+			processedAssets: make(map[string]bool),
+		}
+
+		err := vi.processAsset("missing.js", manifest, assets, "")
+		if err == nil {
+			t.Error("expected error for missing asset")
+		}
+
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestGenerateCryptoNonce(t *testing.T) {
+	t.Parallel()
+
+	nonce1 := generateCryptoNonce()
+	nonce2 := generateCryptoNonce()
+
+	// Should generate non-empty nonces
+	if nonce1 == "" || nonce2 == "" {
+		t.Error("should generate non-empty nonces")
+	}
+
+	// Should generate different nonces
+	if nonce1 == nonce2 {
+		t.Error("should generate different nonces")
+	}
+
+	// Should be base64 encoded (no special characters except +, /, =)
+	for _, c := range nonce1 {
+		valid := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '+' || c == '/' || c == '='
+		if !valid {
+			t.Errorf("nonce contains invalid character: %c", c)
+		}
+	}
+}
+
+func TestViteAssetsHTMLStrings(t *testing.T) {
+	t.Parallel()
+
+	va := &viteAssets{}
+
+	tags := []template.HTML{
+		template.HTML("<link href='a'>"),
+		template.HTML("<link href='b'>"),
+		template.HTML("<link href='c'>"),
+	}
+
+	strings := va.htmlStrings(tags)
+
+	if len(strings) != 3 {
+		t.Errorf("expected 3 strings, got %d", len(strings))
+	}
+
+	if strings[0] != "<link href='a'>" {
+		t.Errorf("unexpected string: %s", strings[0])
+	}
+}
+
+func TestGenerateAllAssets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("routes to hot reload mode", func(t *testing.T) {
+		t.Parallel()
+
+		hotFile := t.TempDir() + "/hot"
+		if err := os.WriteFile(hotFile, []byte("http://localhost:5173"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       hotFile,
+				EntryPoints:   []string{"app.js"},
+				HotReloadPort: "http://localhost:5173",
+			},
+		}
+
+		html, err := vi.generateAllAssets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+		if !strings.Contains(htmlStr, "@vite/client") {
+			t.Error("should include vite client in hot reload mode")
+		}
+
+		if !strings.Contains(htmlStr, "app.js") {
+			t.Error("should include entry point in hot reload mode")
+		}
+	})
+
+	t.Run("routes to production mode", func(t *testing.T) {
+		t.Parallel()
+
+		manifestPath := t.TempDir() + "/manifest.json"
+		manifest := map[string]Asset{
+			"app.js": {
+				File:    "assets/app-abc123.js",
+				IsEntry: true,
+			},
+		}
+		data, _ := json.Marshal(manifest)
+		if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				HotFile:       t.TempDir() + "/nonexistent",
+				BuildManifest: manifestPath,
+				BuildDir:      "/build/",
+				EntryPoints:   []string{"app.js"},
+			},
+		}
+
+		html, err := vi.generateAllAssets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+		if !strings.Contains(htmlStr, "/build/assets/app-abc123.js") {
+			t.Error("should include built asset in production mode")
+		}
+	})
+}
+
+func TestGenerateProductionAssets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates production tags with dependencies", func(t *testing.T) {
+		t.Parallel()
+
+		manifestPath := t.TempDir() + "/manifest.json"
+		manifest := map[string]Asset{
+			"app.js": {
+				File:    "assets/app-abc.js",
+				IsEntry: true,
+				Imports: []string{"vendor.js"},
+				Css:     []string{"app.css"},
+			},
+			"vendor.js": {
+				File: "assets/vendor-def.js",
+			},
+			"app.css": {
+				File: "assets/app-xyz.css",
+			},
+		}
+		data, _ := json.Marshal(manifest)
+		if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				BuildManifest: manifestPath,
+				BuildDir:      "/build/",
+				EntryPoints:   []string{"app.js"},
+			},
+		}
+
+		html, err := vi.generateProductionAssets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+
+		// Should include CSS
+		if !strings.Contains(htmlStr, "/build/assets/app-xyz.css") {
+			t.Error("should include CSS file")
+		}
+
+		// Should include entry script
+		if !strings.Contains(htmlStr, "/build/assets/app-abc.js") {
+			t.Error("should include entry script")
+		}
+	})
+
+	t.Run("error when manifest not found", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				BuildManifest: "/nonexistent/manifest.json",
+				EntryPoints:   []string{"app.js"},
+			},
+		}
+
+		_, err := vi.generateProductionAssets()
+		if err == nil {
+			t.Error("should return error when manifest not found")
+		}
+	})
+
+	t.Run("with nonce", func(t *testing.T) {
+		t.Parallel()
+
+		manifestPath := t.TempDir() + "/manifest.json"
+		manifest := map[string]Asset{
+			"app.js": {
+				File:    "assets/app-abc.js",
+				IsEntry: true,
+			},
+		}
+		data, _ := json.Marshal(manifest)
+		if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		i := &Inertia{}
+		vi := &ViteInstance{
+			Inertia: i,
+			viteConfig: ViteConfig{
+				BuildManifest: manifestPath,
+				BuildDir:      "/build/",
+				EntryPoints:   []string{"app.js"},
+				Nonce:         "test-nonce-123",
+			},
+		}
+
+		html, err := vi.generateProductionAssets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		htmlStr := string(html)
+		if !strings.Contains(htmlStr, `nonce="test-nonce-123"`) {
+			t.Error("should include nonce in tags")
+		}
+	})
+}
+
+func TestViteOptionFunctions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithNonce", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithNonce("test-nonce")(cfg)
+
+		if cfg.Nonce != "test-nonce" {
+			t.Errorf("expected test-nonce, got %s", cfg.Nonce)
+		}
+	})
+
+	t.Run("WithAutoNonce", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithAutoNonce()(cfg)
+
+		if cfg.Nonce == "" {
+			t.Error("Nonce should be auto-generated")
+		}
+
+		if len(cfg.Nonce) == 0 {
+			t.Error("generated nonce should not be empty")
+		}
+	})
+
+	t.Run("WithNonceGenerator", func(t *testing.T) {
+		t.Parallel()
+
+		customGen := func() string { return "custom-nonce" }
+		cfg := &ViteConfig{}
+		WithNonceGenerator(customGen)(cfg)
+
+		if cfg.NonceGenerator == nil {
+			t.Error("NonceGenerator should be set")
+		}
+
+		nonce := cfg.NonceGenerator()
+		if nonce != "custom-nonce" {
+			t.Errorf("expected custom-nonce, got %s", nonce)
+		}
+	})
+
+	t.Run("WithIntegrity", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithIntegrity()(cfg)
+
+		if cfg.IntegrityKey == nil {
+			t.Error("IntegrityKey should be set")
+		}
+
+		if *cfg.IntegrityKey != "integrity" {
+			t.Errorf("expected integrity, got %s", *cfg.IntegrityKey)
+		}
+	})
+
+	t.Run("WithIntegrityKey", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithIntegrityKey("custom-key")(cfg)
+
+		if cfg.IntegrityKey == nil {
+			t.Error("IntegrityKey should be set")
+		}
+
+		if *cfg.IntegrityKey != "custom-key" {
+			t.Errorf("expected custom-key, got %s", *cfg.IntegrityKey)
+		}
+	})
+
+	t.Run("WithEntryPoints", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithEntryPoints("app.js", "admin.js")(cfg)
+
+		if len(cfg.EntryPoints) != 2 {
+			t.Errorf("expected 2 entry points, got %d", len(cfg.EntryPoints))
+		}
+
+		if cfg.EntryPoints[0] != "app.js" {
+			t.Errorf("expected app.js, got %s", cfg.EntryPoints[0])
+		}
+	})
+
+	t.Run("WithoutPreloading", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithoutPreloading()(cfg)
+
+		if cfg.PreloadStrategy != PreloadNone {
+			t.Errorf("expected PreloadNone, got %v", cfg.PreloadStrategy)
+		}
+	})
+
+	t.Run("WithAggressivePreload", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithAggressivePreload()(cfg)
+
+		if cfg.PreloadStrategy != PreloadAggressive {
+			t.Errorf("expected PreloadAggressive, got %v", cfg.PreloadStrategy)
+		}
+	})
+
+	t.Run("WithWaterfallPreload", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &ViteConfig{}
+		WithWaterfallPreload(5)(cfg)
+
+		if cfg.PreloadStrategy != PreloadWaterfall {
+			t.Errorf("expected PreloadWaterfall, got %v", cfg.PreloadStrategy)
+		}
+
+		if cfg.PreloadConcurrent != 5 {
+			t.Errorf("expected 5, got %d", cfg.PreloadConcurrent)
+		}
+	})
+}

--- a/vite_csp.go
+++ b/vite_csp.go
@@ -3,8 +3,8 @@ package gonertia
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
 	"net/http"
+	"strings"
 )
 
 type cspConfig struct {
@@ -24,7 +24,7 @@ func WithCSPNonceGenerator(gen func() string) CSPOption {
 }
 
 // WithCSPPolicy sets a custom CSP policy template.
-// Use %s placeholders where nonces should be inserted.
+// Use {{nonce}} placeholders where nonces should be inserted.
 func WithCSPPolicy(policy string) CSPOption {
 	return func(c *cspConfig) {
 		c.policy = policy
@@ -44,8 +44,8 @@ func WithCSPNonceKey(key string) CSPOption {
 func (vi *ViteInstance) CSPMiddleware(opts ...CSPOption) func(http.Handler) http.Handler {
 	config := &cspConfig{
 		nonceGenerator: generateCryptoNonce,
-		policy: "script-src 'nonce-%s' 'strict-dynamic'; " +
-			"style-src 'nonce-%s'; " +
+		policy: "script-src 'nonce-{{nonce}}' 'strict-dynamic'; " +
+			"style-src 'nonce-{{nonce}}'; " +
 			"font-src 'self' data:; " +
 			"img-src 'self' data: https:; " +
 			"object-src 'none'; " +
@@ -60,7 +60,7 @@ func (vi *ViteInstance) CSPMiddleware(opts ...CSPOption) func(http.Handler) http
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			nonce := config.nonceGenerator()
-			newCSP := fmt.Sprintf(config.policy, nonce, nonce)
+			newCSP := strings.ReplaceAll(config.policy, "{{nonce}}", nonce)
 
 			existing := w.Header().Get("Content-Security-Policy")
 			if existing != "" {

--- a/vite_csp.go
+++ b/vite_csp.go
@@ -1,0 +1,84 @@
+package gonertia
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+)
+
+type cspConfig struct {
+	nonceGenerator func() string
+	policy         string
+	nonceKey       string
+}
+
+// CSPOption configures CSP middleware.
+type CSPOption func(*cspConfig)
+
+// WithCSPNonceGenerator sets a custom nonce generator function.
+func WithCSPNonceGenerator(gen func() string) CSPOption {
+	return func(c *cspConfig) {
+		c.nonceGenerator = gen
+	}
+}
+
+// WithCSPPolicy sets a custom CSP policy template.
+// Use %s placeholders where nonces should be inserted.
+func WithCSPPolicy(policy string) CSPOption {
+	return func(c *cspConfig) {
+		c.policy = policy
+	}
+}
+
+// WithCSPNonceKey sets the template data key for the nonce.
+func WithCSPNonceKey(key string) CSPOption {
+	return func(c *cspConfig) {
+		c.nonceKey = key
+	}
+}
+
+// CSPMiddleware returns middleware that generates per-request CSP nonces.
+// Nonces are added to the Content-Security-Policy header and made available
+// in templates via the configured key (default: "csp_nonce").
+func (vi *ViteInstance) CSPMiddleware(opts ...CSPOption) func(http.Handler) http.Handler {
+	config := &cspConfig{
+		nonceGenerator: generateCryptoNonce,
+		policy: "script-src 'nonce-%s' 'strict-dynamic'; " +
+			"style-src 'nonce-%s'; " +
+			"font-src 'self' data:; " +
+			"img-src 'self' data: https:; " +
+			"object-src 'none'; " +
+			"base-uri 'none'",
+		nonceKey: "csp_nonce",
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nonce := config.nonceGenerator()
+			newCSP := fmt.Sprintf(config.policy, nonce, nonce)
+
+			existing := w.Header().Get("Content-Security-Policy")
+			if existing != "" {
+				w.Header().Set("Content-Security-Policy", existing+"; "+newCSP)
+			} else {
+				w.Header().Set("Content-Security-Policy", newCSP)
+			}
+
+			ctx := SetTemplateDatum(r.Context(), config.nonceKey, nonce)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func generateCryptoNonce() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}

--- a/vite_csp_test.go
+++ b/vite_csp_test.go
@@ -1,0 +1,276 @@
+package gonertia
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCSPMiddlewareDefault(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default configuration", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		handler := vi.CSPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		csp := rec.Header().Get("Content-Security-Policy")
+		if csp == "" {
+			t.Fatal("CSP header not set")
+		}
+
+		if !strings.Contains(csp, "script-src 'nonce-") {
+			t.Error("CSP should contain script-src with nonce")
+		}
+
+		if !strings.Contains(csp, "style-src 'nonce-") {
+			t.Error("CSP should contain style-src with nonce")
+		}
+
+		if !strings.Contains(csp, "object-src 'none'") {
+			t.Error("CSP should contain object-src 'none'")
+		}
+	})
+}
+
+func TestCSPMiddlewareCustom(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom policy", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		handler := vi.CSPMiddleware(
+			WithCSPPolicy("script-src 'nonce-%s'; default-src 'self'"),
+		)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		csp := rec.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "default-src 'self'") {
+			t.Error("CSP should contain custom policy")
+		}
+	})
+
+	t.Run("custom nonce generator", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		called := false
+		customGen := func() string {
+			called = true
+			return "custom-test-nonce"
+		}
+
+		handler := vi.CSPMiddleware(
+			WithCSPNonceGenerator(customGen),
+		)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if !called {
+			t.Error("custom nonce generator should be called")
+		}
+
+		csp := rec.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "custom-test-nonce") {
+			t.Error("CSP should contain custom nonce")
+		}
+	})
+
+	t.Run("custom nonce key", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		var capturedNonce string
+		handler := vi.CSPMiddleware(
+			WithCSPNonceKey("my_custom_nonce"),
+		)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data := TemplateDataFromContext(r.Context())
+			if val, ok := data["my_custom_nonce"]; ok {
+				capturedNonce = val.(string)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if capturedNonce == "" {
+			t.Error("custom nonce key should be set in template data")
+		}
+	})
+}
+
+func TestCSPMiddlewareMerge(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges with existing CSP header", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		handler := vi.CSPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		rec.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
+
+		handler.ServeHTTP(rec, req)
+
+		csp := rec.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "frame-ancestors 'none'") {
+			t.Error("should preserve existing CSP directive")
+		}
+
+		if !strings.Contains(csp, "script-src 'nonce-") {
+			t.Error("should add new CSP directives")
+		}
+	})
+}
+
+func TestCSPMiddlewareContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nonce is available in context", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		var contextNonce string
+		handler := vi.CSPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data := TemplateDataFromContext(r.Context())
+			if val, ok := data["csp_nonce"]; ok {
+				contextNonce = val.(string)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if contextNonce == "" {
+			t.Error("nonce should be available in context")
+		}
+
+		csp := rec.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, contextNonce) {
+			t.Error("nonce in context should match nonce in CSP header")
+		}
+	})
+
+	t.Run("generates unique nonces per request", func(t *testing.T) {
+		t.Parallel()
+
+		i := &Inertia{}
+		vi := &ViteInstance{Inertia: i}
+
+		var nonce1, nonce2 string
+		handler := vi.CSPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec1 := httptest.NewRecorder()
+		handler.ServeHTTP(rec1, req1)
+		csp1 := rec1.Header().Get("Content-Security-Policy")
+		parts1 := strings.Split(csp1, "'nonce-")
+		if len(parts1) > 1 {
+			nonce1 = strings.Split(parts1[1], "'")[0]
+		}
+
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec2 := httptest.NewRecorder()
+		handler.ServeHTTP(rec2, req2)
+		csp2 := rec2.Header().Get("Content-Security-Policy")
+		parts2 := strings.Split(csp2, "'nonce-")
+		if len(parts2) > 1 {
+			nonce2 = strings.Split(parts2[1], "'")[0]
+		}
+
+		if nonce1 == "" || nonce2 == "" {
+			t.Fatal("nonces should be generated")
+		}
+
+		if nonce1 == nonce2 {
+			t.Error("nonces should be unique per request")
+		}
+	})
+}
+
+func TestCSPOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithCSPPolicy", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &cspConfig{}
+		WithCSPPolicy("custom policy")(cfg)
+
+		if cfg.policy != "custom policy" {
+			t.Errorf("expected 'custom policy', got %s", cfg.policy)
+		}
+	})
+
+	t.Run("WithCSPNonceGenerator", func(t *testing.T) {
+		t.Parallel()
+
+		customGen := func() string { return "test" }
+		cfg := &cspConfig{}
+		WithCSPNonceGenerator(customGen)(cfg)
+
+		if cfg.nonceGenerator == nil {
+			t.Error("nonceGenerator should be set")
+		}
+
+		if cfg.nonceGenerator() != "test" {
+			t.Error("nonceGenerator should return expected value")
+		}
+	})
+
+	t.Run("WithCSPNonceKey", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &cspConfig{}
+		WithCSPNonceKey("custom_key")(cfg)
+
+		if cfg.nonceKey != "custom_key" {
+			t.Errorf("expected 'custom_key', got %s", cfg.nonceKey)
+		}
+	})
+}

--- a/vite_csp_test.go
+++ b/vite_csp_test.go
@@ -54,7 +54,7 @@ func TestCSPMiddlewareCustom(t *testing.T) {
 		vi := &ViteInstance{Inertia: i}
 
 		handler := vi.CSPMiddleware(
-			WithCSPPolicy("script-src 'nonce-%s'; default-src 'self'"),
+			WithCSPPolicy("script-src 'nonce-{{nonce}}'; default-src 'self'"),
 		)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/vite_test.go
+++ b/vite_test.go
@@ -229,12 +229,12 @@ func TestFindManifest(t *testing.T) {
 		createBuild    bool
 		createFallback bool
 		expectError    bool
-		expectMove     bool
+		expectPath     string
 	}{
-		{"build exists", true, false, false, false},
-		{"fallback exists", false, true, false, true},
-		{"both exist", true, true, false, false}, // build takes priority
-		{"neither exists", false, false, true, false},
+		{"build exists", true, false, false, buildManifest},
+		{"fallback exists", false, true, false, fallbackManifest},
+		{"both exist", true, true, false, buildManifest},
+		{"neither exists", false, false, true, ""},
 	}
 
 	for _, tt := range tests {
@@ -247,9 +247,12 @@ func TestFindManifest(t *testing.T) {
 				return
 			}
 
-			assertManifestSuccess(t, err, path, buildManifest)
-			if tt.expectMove {
-				assertManifestMove(t, buildManifest, fallbackManifest)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if path != tt.expectPath {
+				t.Errorf("findManifest() = %q, want %q", path, tt.expectPath)
 			}
 		})
 	}
@@ -282,26 +285,6 @@ func assertManifestError(t *testing.T, err error) {
 	t.Helper()
 	if err == nil {
 		t.Error("findManifest() expected error but got none")
-	}
-}
-
-func assertManifestSuccess(t *testing.T, err error, path, buildManifest string) {
-	t.Helper()
-	if err != nil {
-		t.Fatalf("findManifest() unexpected error: %v", err)
-	}
-	if path != buildManifest {
-		t.Errorf("findManifest() = %q, want %q", path, buildManifest)
-	}
-}
-
-func assertManifestMove(t *testing.T, buildManifest, fallbackManifest string) {
-	t.Helper()
-	if _, err := os.Stat(buildManifest); err != nil {
-		t.Error("fallback manifest should have been moved to build location")
-	}
-	if _, err := os.Stat(fallbackManifest); err == nil {
-		t.Error("fallback manifest should have been moved away")
 	}
 }
 


### PR DESCRIPTION
- Add [CSP](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce) Support (can be customized). It ensures the assets comes from you. It could be paired with a logic somewhere with a middleware.  Laravel for now has a fixed nonce instead of having a different nonce per request.
- Added assets preloading strategy (like [laravel](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Vite.php))
  - no preloading (like before)
  - aggressive
  - waterfall
- added `{{ viteAssets }}` entrypoint can be set on the back or on the html. 
- added `{{ viteAssetsWithNonce .csp_nonce }}` to be able to send csp nonce to render-renderer.
- added `.CSPMiddleware()` on vite instance.

- added integrity checking, there is a package for vite which write integrity for each files. The package is old, but it is just a single file and it works. 

No breaking change. But it should be either `{{ vite ....}}` we can call it "manual" mode, or the new one, "automatic mode". Everything is opt-in.


as a note: some framework, like VueJS (tested) might include inline css. we can apply nonce with this

```js
    <script nonce="{{.csp_nonce}}">        
        window.__CSP_NONCE__ = "{{.csp_nonce}}";
    </script>
```

```js
# part of your application js entry point
function contentSecurityPolicy() {
  const nonce = window.__CSP_NONCE__;

  document.querySelectorAll("style").forEach((el) => {
    if (!el.hasAttribute("nonce")) el.setAttribute("nonce", nonce);
  });

  const observer = new MutationObserver((mutations) => {
    for (const mutation of mutations) {
      for (const node of mutation.addedNodes) {
        if (node.tagName === "STYLE" && !node.hasAttribute("nonce")) {
          node.setAttribute("nonce", nonce);
        }
      }
    }
  });

  observer.observe(document.head, { childList: true });
}
```

Basically 
